### PR TITLE
Part 1 of issue #34, not integrated with the coordinator yet

### DIFF
--- a/m_etcd/ttlRefresher_test.go
+++ b/m_etcd/ttlRefresher_test.go
@@ -69,11 +69,11 @@ func TestTtlRefresherTiming(t *testing.T) {
 	}
 	time.Sleep(1 * time.Second)
 	if len(runHistory) != 1 {
-		t.Fatal("The tasks should have fired once and only once.  But it fired %s times.", len(runHistory))
+		t.Fatal("The tasks should have fired once and only once.  But it fired %d times.", len(runHistory))
 	}
 	nRefresher.UnscheduleTTLRefresh(testPaths[0])
 	time.Sleep(2 * time.Second)
 	if len(runHistory) != 1 {
-		t.Fatal("The tasks should have fired once and only once.  But it fired %s times.", len(runHistory))
+		t.Fatal("The tasks shouldn't have fired again.  But it most have because fired times is now %d.", len(runHistory))
 	}
 }


### PR DESCRIPTION
This is part one of the heartbeat (the hard part) it add a scheduler that will eventually run within the coordinator, which will use this to register etc path/ttls.  It will make sure the paths have their ttls updated before they expire. 
