### PR TITLE
Fix balancer blocking on send during shutdown

### DIFF
--- a/metafora.go
+++ b/metafora.go
@@ -106,7 +106,13 @@ func (c *Consumer) Run() {
 				// Shutdown has been called.
 				return
 			case <-time.After(c.balEvery + time.Duration(randInt(balanceJitterMax))):
-				balance <- true
+				select {
+				case balance <- true:
+					// Ticked balance
+				case <-c.stop:
+					// Shutdown has been called.
+					return
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
If the consumer shuts down while the balancer is trying to say Hi to the mainloop, it will block forever.

Not a big deal as it will probably only happen at shutdown, but leaking goroutines is bad.
