### PR TITLE
Export Consumer.Frozen and add http introspection handler

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,0 +1,37 @@
+package httputil
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// Consumer contains just the Metafora methods exposed by the HTTP
+// introspection endpoints.
+type Consumer interface {
+	Frozen() bool
+	Tasks() []string
+}
+
+// InfoResponse is the JSON response marshalled by the MakeInfoHandler.
+type InfoResponse struct {
+	Frozen  bool      `json:"frozen"`
+	Node    string    `json:"node"`
+	Started time.Time `json:"started"`
+	Tasks   []string  `json:"tasks"`
+}
+
+// MakeInfoHandler returns an HTTP handler which can be added to an exposed
+// HTTP server mux by Metafora applications to provide operators with basic
+// node introspection.
+func MakeInfoHandler(c Consumer, node string, started time.Time) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(&InfoResponse{
+			Frozen:  c.Frozen(),
+			Node:    node,
+			Started: started,
+			Tasks:   c.Tasks(),
+		})
+	}
+}

--- a/httputil/httputil_test.go
+++ b/httputil/httputil_test.go
@@ -1,0 +1,58 @@
+package httputil_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lytics/metafora"
+	. "github.com/lytics/metafora/httputil"
+)
+
+type tc struct {
+	stop chan bool
+}
+
+func (*tc) Init(metafora.CoordinatorContext) error { return nil }
+func (c *tc) Watch() (string, error) {
+	<-c.stop
+	return "", nil
+}
+func (c *tc) Claim(string) bool { return false }
+func (c *tc) Release(string)    {}
+func (c *tc) Done(string)       {}
+func (c *tc) Command() (metafora.Command, error) {
+	<-c.stop
+	return nil, nil
+}
+func (c *tc) Close() { close(c.stop) }
+
+func TestMakeInfoHandler(t *testing.T) {
+	t.Parallel()
+
+	c, _ := metafora.NewConsumer(&tc{stop: make(chan bool)}, nil, &metafora.DumbBalancer{})
+	defer c.Shutdown()
+	name := "test-name"
+	now := time.Now().Truncate(time.Second)
+
+	resp := httptest.NewRecorder()
+	MakeInfoHandler(c, name, now)(resp, nil)
+
+	info := InfoResponse{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &info); err != nil {
+		t.Fatalf("Error unmarshalling response body: %v", err)
+	}
+	if info.Frozen {
+		t.Errorf("Consumer should not start frozen.")
+	}
+	if !info.Started.Equal(now) {
+		t.Errorf("Started time %s != %s", info.Started, now)
+	}
+	if info.Node != name {
+		t.Errorf("Node name %s != %s", info.Node, name)
+	}
+	if len(info.Tasks) != 0 {
+		t.Errorf("Unexpected tasks: %v", info.Tasks)
+	}
+}

--- a/metafora_test.go
+++ b/metafora_test.go
@@ -101,7 +101,7 @@ func TestConsumer(t *testing.T) {
 	hf, tasksRun := newTestHandlerFunc(t)
 
 	// Create the consumer and run it
-	c, _ := NewConsumer(tc, hf, &DumbBalancer{})
+	c, _ := NewConsumer(tc, hf, bal)
 	s := make(chan int)
 	start := time.Now()
 	go func() {


### PR DESCRIPTION
The http handler is copied from our internal metafora runner.
