### PR TITLE
Preview: Balancer that adds task to node affinity.  Uses QLBridge for selector parsing. 

### DIFF
--- a/decorators/balancer.go
+++ b/decorators/balancer.go
@@ -1,0 +1,93 @@
+package metafora
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/lytics/metafora"
+)
+
+/*
+	Selectors are associated with tasks
+
+	If any selector matches any label, we return true (For now).   We can look into add
+	a more advance lexer/parser for selectors if we want...
+*/
+type SelectorSet map[string]interface{}
+
+func (s SelectorSet) Matches(l LabelSet) (bool, error) {
+	for sel, _ := range s {
+		for label, _ := range l {
+			matched, err := regexp.MatchString(sel, label)
+			if err != nil {
+				return false, err
+			} else if matched {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+type LabelSet map[string]interface{}
+
+type MetadataClient interface {
+	Selectors(taskid string) SelectorSet
+	Labels(nodeid string) LabelSet
+}
+
+func WrapBalancerAsSelectable(nodeid string, baseBalancer metafora.Balancer, cs metafora.ClusterState, md MetadataClient) metafora.Balancer {
+	return &SelectBalancer{
+		nodeid: nodeid,
+		cs:     cs,
+		md:     md,
+		bc:     nil,
+		base:   baseBalancer,
+	}
+}
+
+//Add the selectable layer to an existing balancer strategy
+type SelectBalancer struct {
+	nodeid string
+	cs     metafora.ClusterState
+	md     MetadataClient
+	bc     metafora.BalancerContext
+	base   metafora.Balancer // Decorator pattern,
+}
+
+func (b *SelectBalancer) Init(s metafora.BalancerContext) {
+	b.bc = s
+	b.base.Init(s)
+}
+
+func (b *SelectBalancer) CanClaim(taskid string) bool {
+
+	selectors := b.md.Selectors(taskid)
+	labels := b.md.Labels(b.nodeid)
+
+	if len(selectors) > 0 { //If no selectors defined for task, then just use the base balancer
+		matches, err := selectors.Matches(labels)
+		if err != nil {
+			b.bc.Log(metafora.LogLevelWarn, "Error processing selectors: taskid:%v labels:[%v] selectors:[%v] error:%v", taskid, labels, selectors, err)
+			return false
+		}
+		if !matches {
+			return false
+		}
+	}
+
+	//If all conditions are met, then do fair balancing
+	// if this was one of our released tasks then delay claiming it, vs rejecting it
+	// We maybe the only node that can reclaim the task due to selectors/labels.
+	if !b.base.CanClaim(taskid) {
+		time.Sleep(200 * time.Millisecond)
+		return true
+	}
+
+	return true
+}
+
+// Balance releases tasks based on what the base balancer decides
+func (b *SelectBalancer) Balance() []string {
+	return b.base.Balance()
+}

--- a/decorators/balancer.go
+++ b/decorators/balancer.go
@@ -24,7 +24,14 @@ func init() {
 //                 MetadataClient for etcd can read them out.
 
 /*
-	Selectors are associated with tasks
+	Selectors are associated with task ids, to allow that task to be
+	picky about which nodes it'll accept.
+
+	Example Selectors :
+	   eq(fastnetwork,"1") AND eq(highmemory,"1") AND contains(binary_version, 2.12)
+	   eq(freemium_node,"1")
+	   contains(host_name,"prod")
+	   contains(allowed_accounts,"123")
 */
 type Selector string
 

--- a/decorators/balancer.go
+++ b/decorators/balancer.go
@@ -1,41 +1,86 @@
 package metafora
 
 import (
-	"regexp"
+	"fmt"
+	"net/url"
+	"os"
 	"time"
 
+	"github.com/araddon/qlbridge/builtins"
+	"github.com/araddon/qlbridge/vm"
 	"github.com/lytics/metafora"
 )
 
+func init() {
+	builtins.LoadAllBuiltins()
+}
+
+//TODO Write an ETCD implementation for:
+//   1 TaskClient - A metafora client that writes a `selector` to etcd during while
+//                 creating the task
+//	 2 EtcdMetaData - implements the etcd Metadata client used by the Selectable Balancer
+//                 to look up Metadata info by taskspace
+//   3 Etcd Main() Example that shows adding labels for the nodeid to etcd, so the
+//                 MetadataClient for etcd can read them out.
+
 /*
 	Selectors are associated with tasks
-
-	If any selector matches any label, we return true (For now).   We can look into add
-	a more advance lexer/parser for selectors if we want...
 */
-type SelectorSet map[string]interface{}
+type Selector string
 
-func (s SelectorSet) Matches(l LabelSet) (bool, error) {
-	for sel, _ := range s {
-		for label, _ := range l {
-			matched, err := regexp.MatchString(sel, label)
-			if err != nil {
-				return false, err
-			} else if matched {
-				return true, nil
-			}
-		}
+func (s Selector) Matches(l url.Values, hd url.Values) (bool, error) {
+	vals := make(url.Values)
+	for k, v := range hd {
+		vals[k] = v
 	}
+	for k, v := range l { // labels can override hostdata.
+		vals[k] = v
+	}
+
+	writeContext := vm.NewContextSimple()
+	readContext := vm.NewContextUrlValues(vals)
+
+	exprVm, err := vm.NewVm(string(s))
+	if err != nil {
+		return false, err
+	}
+
+	err = exprVm.Execute(writeContext, readContext)
+	if err != nil {
+		return false, err
+	}
+
+	val, ok := writeContext.Get("")
+
+	if ok {
+		switch v := val.Value().(type) {
+		case bool:
+			return v, nil // happy path
+		default:
+			return false, fmt.Errorf("metafora: selector: unknown type from write context")
+		}
+	} else {
+		return false, fmt.Errorf("metafora: selector: failed to get value from write context")
+	}
+
 	return false, nil
 }
 
-type LabelSet map[string]interface{}
+const HostName = "host_name"
 
-type MetadataClient interface {
-	Selectors(taskid string) SelectorSet
-	Labels(nodeid string) LabelSet
+func hostdata() url.Values {
+	d := make(url.Values)
+	host, _ := os.Hostname()
+	d.Set(HostName, host)
+	return d
 }
 
+type MetadataClient interface {
+	Selector(taskid string) Selector
+	Labels(nodeid string) url.Values
+}
+
+//Balancer logic below here:
 func WrapBalancerAsSelectable(nodeid string, baseBalancer metafora.Balancer, cs metafora.ClusterState, md MetadataClient) metafora.Balancer {
 	return &SelectBalancer{
 		nodeid: nodeid,
@@ -61,14 +106,20 @@ func (b *SelectBalancer) Init(s metafora.BalancerContext) {
 }
 
 func (b *SelectBalancer) CanClaim(taskid string) bool {
+	defer func() {
+		if r := recover(); r != nil {
+			b.bc.Log(metafora.LogLevelError, "metafora: selector: panic'ed taskid:%v panic_msg:%v", taskid, r)
+		}
+	}()
 
-	selectors := b.md.Selectors(taskid)
+	selector := b.md.Selector(taskid)
 	labels := b.md.Labels(b.nodeid)
+	hostdata := hostdata()
 
-	if len(selectors) > 0 { //If no selectors defined for task, then just use the base balancer
-		matches, err := selectors.Matches(labels)
+	if selector != "" { //If no selectors defined for task, then just use the base balancer
+		matches, err := selector.Matches(labels, hostdata)
 		if err != nil {
-			b.bc.Log(metafora.LogLevelWarn, "Error processing selectors: taskid:%v labels:[%v] selectors:[%v] error:%v", taskid, labels, selectors, err)
+			b.bc.Log(metafora.LogLevelWarn, "Error processing selectors: taskid:%v labels:[%v] selectors:[%v] error:%v", taskid, labels, selector, err)
 			return false
 		}
 		if !matches {

--- a/decorators/balancer_dec_test.go
+++ b/decorators/balancer_dec_test.go
@@ -1,0 +1,123 @@
+package metafora
+
+import (
+	"testing"
+
+	"github.com/lytics/metafora"
+)
+
+//TODO Add support for boolean options between selectors.
+//
+// For cases like:
+//   labels contains(highmemory && fastnetwork)
+// The current code only supports:
+//   labels contains(highmemory || fastnetwork)
+// With the || being implicit
+
+func TestSelectDecoratorWithFairBalancerOneNode(t *testing.T) {
+	const NodeId = "node1"
+	const taskIdNoSels = "32"
+	const taskIdWithSels = "42"
+	const taskIdWithSelsThatDontMatchAnyLabels = "2003"
+
+	// Single node should never release tasks
+	clusterstate := &TestClusterState{
+		Current: map[string]int{NodeId: 5},
+	}
+
+	mclient := &testMetadataClient{
+		sels: map[string]SelectorSet{
+			taskIdWithSels: SelectorSet{
+				"fastnetwork": nil,
+			},
+			taskIdWithSelsThatDontMatchAnyLabels: SelectorSet{
+				"highmemory": nil,
+			},
+		},
+		labs: map[string]LabelSet{
+			NodeId: LabelSet{
+				"fastnetwork": nil,
+			},
+		},
+	}
+
+	consumerstate := &TestConsumerState{
+		[]string{"1", "2", "3", "4", "5"},
+		newTestlogger(t),
+	}
+
+	fb := metafora.NewDefaultFairBalancer(NodeId, clusterstate)
+	fb.Init(consumerstate)
+
+	sb := WrapBalancerAsSelectable(NodeId, fb, clusterstate, mclient)
+
+	if !sb.CanClaim(taskIdNoSels) {
+		t.Fatal("Expected claim to be true")
+	}
+
+	if !sb.CanClaim(taskIdWithSels) {
+		t.Fatal("Expected claim to be true")
+	}
+
+	if sb.CanClaim(taskIdWithSelsThatDontMatchAnyLabels) {
+		t.Fatal("Expected claim to be false")
+	}
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//  Below this line are test case implementation for any interfaces needed
+
+///////////////////////////////////////
+// decorators.MetadataClient
+type testMetadataClient struct {
+	sels map[string]SelectorSet
+	labs map[string]LabelSet
+}
+
+func (md *testMetadataClient) Selectors(taskid string) SelectorSet {
+	return md.sels[taskid]
+}
+func (md *testMetadataClient) Labels(nodeid string) LabelSet {
+	return md.labs[nodeid]
+}
+
+///////////////////////////////////////
+// metafora.ClusterState interface
+type TestClusterState struct {
+	Current map[string]int
+	Err     error
+}
+
+func (ts *TestClusterState) NodeTaskCount() (map[string]int, error) {
+	if ts.Err != nil {
+		return nil, ts.Err
+	}
+
+	return ts.Current, nil
+}
+
+///////////////////////////////////////
+// metafora.ConsumerState interface
+type TestConsumerState struct {
+	Current []string
+	metafora.Logger
+}
+
+func (tc *TestConsumerState) Tasks() []string {
+	return tc.Current
+}
+
+///////////////////////////////////////
+// metafora.Logger interface
+type testlogger struct {
+	t *testing.T
+}
+
+func newTestlogger(t *testing.T) *testlogger {
+	return &testlogger{t: t}
+}
+
+func (l *testlogger) Log(lvl metafora.LogLevel, msg string, args ...interface{}) {
+	l.t.Logf(msg, args...)
+}


### PR DESCRIPTION
In some cases a task my have requirements to be assigned to nodes with special features or labels.   This is a the start of adding support for that.