### PR TITLE
Don't block releasing forever on shutdown

### DIFF
--- a/embedded/coordinator.go
+++ b/embedded/coordinator.go
@@ -56,7 +56,10 @@ func (e *EmbeddedCoordinator) Claim(taskID string) bool {
 }
 
 func (e *EmbeddedCoordinator) Release(taskID string) {
-	e.inchan <- taskID
+	select {
+	case e.inchan <- taskID:
+	case <-e.stopchan:
+	}
 }
 
 func (e *EmbeddedCoordinator) Done(taskID string) {}


### PR DESCRIPTION
When shutting down an embedded coordinator, the consumer may try to release a task after the embedded coordinator  has been stopped. That could deadlock before this fix.

This fix "throws away" the release, but since it's during shutdown of the embedded coordinator all of the tasks are getting thrown away anyway.
