### PR TITLE
Fix double task release on shutdown

### DIFF
--- a/command.go
+++ b/command.go
@@ -3,11 +3,10 @@ package metafora
 import "encoding/json"
 
 const (
-	cmdFreeze      = "freeze"
-	cmdUnfreeze    = "unfreeze"
-	cmdBalance     = "balance"
-	cmdReleaseTask = "release_task"
-	cmdStopTask    = "stop_task"
+	cmdFreeze   = "freeze"
+	cmdUnfreeze = "unfreeze"
+	cmdBalance  = "balance"
+	cmdStopTask = "stop_task"
 )
 
 // Commands are a way clients can communicate directly with nodes for cluster
@@ -72,12 +71,7 @@ func CommandBalance() Command {
 	return &command{C: cmdBalance}
 }
 
-// CommandReleaseTask forces a node to stop and release a task even if frozen.
-func CommandReleaseTask(task string) Command {
-	return &command{C: cmdReleaseTask, P: map[string]interface{}{"task": task}}
-}
-
-// CommandStopTask forces a node to stop and remove a task even if frozen.
+// CommandStopTask forces a node to stop a task even if frozen.
 func CommandStopTask(task string) Command {
 	return &command{C: cmdStopTask, P: map[string]interface{}{"task": task}}
 }

--- a/command_test.go
+++ b/command_test.go
@@ -38,6 +38,5 @@ func TestCommands(t *testing.T) {
 	testCmd(t, CommandFreeze(), "freeze", nil)
 	testCmd(t, CommandUnfreeze(), "unfreeze", nil)
 	testCmd(t, CommandBalance(), "balance", nil)
-	testCmd(t, CommandReleaseTask("test"), "release_task", map[string]interface{}{"task": "test"})
 	testCmd(t, CommandStopTask("test"), "stop_task", map[string]interface{}{"task": "test"})
 }

--- a/coordinator.go
+++ b/coordinator.go
@@ -56,7 +56,5 @@ type coordinatorContext struct {
 // calling by Coordinator implementations via the CoordinatorContext interface.
 func (ctx *coordinatorContext) Lost(taskID string) {
 	ctx.Log(LogLevelError, "Lost task %s", taskID)
-	if !ctx.stopTask(taskID) {
-		ctx.Log(LogLevelWarn, "Lost task %s wasn't running.", taskID)
-	}
+	ctx.stopTask(taskID)
 }

--- a/m_etcd/coordinator.go
+++ b/m_etcd/coordinator.go
@@ -165,7 +165,7 @@ func (ec *EtcdCoordinator) upsertDir(path string, ttl uint64) {
 	}
 }
 
-// nodeRefresher is in chage of keeping the node entry in etcd alive. If it's
+// nodeRefresher is in charge of keeping the node entry in etcd alive. If it's
 // unable to communicate with etcd it must shutdown the coordinator.
 //
 // watch retries on errors and taskmgr calls Lost(task) on tasks it can't

--- a/metafora.go
+++ b/metafora.go
@@ -287,7 +287,7 @@ func (c *Consumer) balance() {
 		c.logger.Log(LogLevelInfo, "Balancer releasing: %v", tasks)
 	}
 	for _, task := range tasks {
-		go c.stopTask(task)
+		c.stopTask(task)
 	}
 }
 
@@ -297,9 +297,8 @@ func (c *Consumer) shutdown() {
 	tasks := c.Tasks()
 	c.logger.Log(LogLevelInfo, "Sending stop signal to %d handler(s)", len(tasks))
 
-	// Concurrently shutdown handlers as they may take a while to shutdown
 	for _, id := range tasks {
-		go c.stopTask(id)
+		c.stopTask(id)
 	}
 
 	c.logger.Log(LogLevelInfo, "Waiting for handlers to exit")

--- a/slowtask_test.go
+++ b/slowtask_test.go
@@ -27,7 +27,7 @@ func TestDoubleRelease(t *testing.T) {
 	reallyStop := make(chan bool)
 	h := SimpleHandler(func(task string, stop <-chan bool) bool {
 		started <- 1
-		t.Logf("TestDoubleRelease handler recieved %s - blocking until reallStop closed.", task)
+		t.Logf("TestDoubleRelease handler recieved %s - blocking until reallyStop closed.", task)
 		<-reallyStop
 		return true
 	})


### PR DESCRIPTION
Back when we made Run's return value (done bool) in 26274e5 -- that
implicitly made Run the sole arbiter of whether or not to Release a task
or Mark it as done.

The only thing the core Consumer should do is tell handlers to Stop --
it should only ever call Release or Done after Run exits and use that
return value.

We do lose the ReleaseTask command (since now it's the same as the
StopTask command), but we've never used it and it can be added later if
it's found to be valuable.