### PR TITLE
Don't block Releases on corresponding Watches

### DIFF
--- a/metafora.go
+++ b/metafora.go
@@ -327,8 +327,8 @@ func (c *Consumer) Shutdown() {
 	// Wait for task handlers to exit.
 	c.hwg.Wait()
 
-	// Make sure Run() exits, otherwise coord.Close() might not finish before
-	// exiting.
+	// Make sure Run() exits, otherwise Shutdown() might exit before
+	// coord.Close() is called.
 	c.runwgL.Lock()
 	c.runwg.Wait()
 	c.runwgL.Unlock()


### PR DESCRIPTION
This fixes a deadlock in embedded tests where a task is released during shutdown but there's no watcher to accept it.

Related to #94