### PR TITLE
Implement resource balancer

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -17,7 +17,7 @@ type BalancerContext interface {
 	// Tasks returns a sorted list of task IDs run by this Consumer. The Consumer
 	// stops task manipulations during claiming and balancing, so the list will
 	// be accurate unless a task naturally completes.
-	Tasks() []string
+	Tasks() []Task
 
 	Logger
 }
@@ -127,7 +127,7 @@ func (e *FairBalancer) Balance() []string {
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	nodetasks := e.bc.Tasks()
 	for len(releasetasks) < shouldrelease {
-		tid := nodetasks[random.Intn(len(nodetasks))]
+		tid := nodetasks[random.Intn(len(nodetasks))].ID()
 		releasetasks = append(releasetasks, tid)
 		e.lastreleased[tid] = true
 	}

--- a/balancer_res.go
+++ b/balancer_res.go
@@ -24,9 +24,8 @@ type ResourceReporter interface {
 // threshold (otherwise claims would continue just to have the work
 // rebalanced.)
 //
-// Furthermore, claims are delayed by the how far below the threshold the node
-// is in milliseconds. This is intended to give a slight advantage to nodes
-// with more free resources.
+// Even below the claim limit, claims are delayed by the percent of resources
+// used (in milliseconds) to give less loaded nodes a claim advantage.
 //
 // The balancer releases the oldest tasks first (skipping those who are already
 // stopping) to try to prevent rebalancing the same tasks repeatedly within a

--- a/balancer_res.go
+++ b/balancer_res.go
@@ -1,0 +1,107 @@
+package metafora
+
+import (
+	"fmt"
+	"time"
+)
+
+// ResourceReporter is required by the ResourceBalancer to read the resource
+// being used for balancing.
+type ResourceReporter interface {
+	// Used returns the amount of a resource used and the total amount of that
+	// resource.
+	Used() (used uint64, total uint64)
+
+	// String returns the plural name of the unit resources are reported in.
+	String() string
+}
+
+// ResourceBalancer is a balancer implemntation which uses two thresholds to
+// limit claiming and rebalance work based upon a resource reported by a
+// ResourceReporter. When the claim threshold is exceeded, no new work will be
+// claimed. When the release threshold is exceeded work will be released until
+// below that threshold. The claim threshold must be less than the release
+// threshold (otherwise claims would continue just to have the work
+// rebalanced.)
+//
+// Furthermore, claims are delayed by the how far below the threshold the node
+// is in milliseconds. This is intended to give a slight advantage to nodes
+// with more free resources.
+//
+// The balancer releases the oldest tasks first (skipping those who are already
+// stopping) to try to prevent rebalancing the same tasks repeatedly within a
+// cluster.
+type ResourceBalancer struct {
+	ctx      BalancerContext
+	reporter ResourceReporter
+
+	claimLimit   int
+	releaseLimit int
+}
+
+// NewResourceBalancer creates a new ResourceBalancer or returns an error if
+// the limits are invalid.
+func NewResourceBalancer(src ResourceReporter, claimLimit, releaseLimit int) (*ResourceBalancer, error) {
+	if claimLimit < 1 || claimLimit > 100 || releaseLimit < 1 || releaseLimit > 100 {
+		return nil, fmt.Errorf("Limits must be between 1 and 100. claim=%d release=%d", claimLimit, releaseLimit)
+	}
+	if claimLimit >= releaseLimit {
+		return nil, fmt.Errorf("Claim threshold must be < release threshold. claim=%d >= release=%d", claimLimit, releaseLimit)
+	}
+
+	return &ResourceBalancer{
+		reporter:     src,
+		claimLimit:   claimLimit,
+		releaseLimit: releaseLimit,
+	}, nil
+}
+
+func (b *ResourceBalancer) Init(ctx BalancerContext) {
+	b.ctx = ctx
+}
+
+func (b *ResourceBalancer) CanClaim(string) bool {
+	used, total := b.reporter.Used()
+	threshold := int(float32(used) / float32(total) * 100)
+	if threshold >= b.claimLimit {
+		//FIXME Until #93 is fixed returning false is very dangerous as it could
+		//      cause a tight loop with the coordinator. Sleep longer than more
+		//      lightly loaded nodes.
+		dur := time.Duration(100+(threshold-b.claimLimit)) * time.Millisecond
+		b.ctx.Log(LogLevelInfo, "%d is over the claim limit of %d. Used %d of %d %s. Sleeping %s before claiming.",
+			threshold, b.claimLimit, used, total, b.reporter, dur)
+		time.Sleep(dur)
+		return true
+	}
+
+	// Always sleep based on resource usage to give less loaded nodes an advantage
+	dur := time.Duration(threshold) * time.Millisecond
+	time.Sleep(dur)
+	return true
+}
+
+func (b *ResourceBalancer) Balance() []string {
+	used, total := b.reporter.Used()
+	threshold := int(float32(used) / float32(total) * 100)
+	if threshold < b.releaseLimit {
+		// We're below the limit! Don't release anything.
+		return nil
+	}
+
+	// Release the oldest task that isn't already stopping
+	var task Task
+	for _, t := range b.ctx.Tasks() {
+		if t.Stopped().IsZero() && (task == nil || task.Started().After(t.Started())) {
+			task = t
+		}
+	}
+
+	// No tasks or all tasks are stopping, don't bother rebalancing
+	if task == nil {
+		return nil
+	}
+
+	b.ctx.Log(LogLevelInfo, "Releasing task %s (started %s) because %d > %d (%d of %d %s used)",
+		task.ID(), task.Started(), threshold, b.releaseLimit, used, total, b.reporter)
+	return []string{task.ID()}
+}

--- a/balancer_res.go
+++ b/balancer_res.go
@@ -12,7 +12,7 @@ type ResourceReporter interface {
 	// resource.
 	Used() (used uint64, total uint64)
 
-	// String returns the plural name of the unit resources are reported in.
+	// String returns the unit resources are reported in.
 	String() string
 }
 
@@ -40,6 +40,9 @@ type ResourceBalancer struct {
 
 // NewResourceBalancer creates a new ResourceBalancer or returns an error if
 // the limits are invalid.
+//
+// Limits should be a percentage expressed as an integer between 1 and 100
+// inclusive.
 func NewResourceBalancer(src ResourceReporter, claimLimit, releaseLimit int) (*ResourceBalancer, error) {
 	if claimLimit < 1 || claimLimit > 100 || releaseLimit < 1 || releaseLimit > 100 {
 		return nil, fmt.Errorf("Limits must be between 1 and 100. claim=%d release=%d", claimLimit, releaseLimit)

--- a/balancer_res_test.go
+++ b/balancer_res_test.go
@@ -1,0 +1,57 @@
+package metafora
+
+import "testing"
+
+type fakeReporter struct {
+	used  uint64
+	total uint64
+}
+
+func (r *fakeReporter) Used() (uint64, uint64) { return r.used, r.total }
+func (r *fakeReporter) String() string         { return "fakes" }
+
+func TestResourceBalancer(t *testing.T) {
+	t.Parallel()
+
+	fr := &fakeReporter{used: 750, total: 1000}
+	_, err := NewResourceBalancer(fr, 80, 75)
+	if err == nil {
+		t.Fatal("Expected an error: release threshold was lower than claim.")
+	}
+
+	bal, err := NewResourceBalancer(fr, 80, 90)
+	if err != nil {
+		t.Fatalf("Unexpected error creating resource balancer: %v", err)
+	}
+
+	ctx := &TestConsumerState{
+		Current: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"},
+		Logger:  LogT(t),
+	}
+	bal.Init(ctx)
+
+	release := bal.Balance()
+	if len(release) > 0 {
+		t.Errorf("Released tasks when we were well below limits! %v", release)
+	}
+
+	// Bump resource usage and rebalance
+	fr.used = 901
+	release = bal.Balance()
+	if len(release) != 1 && release[0] == "1" {
+		t.Errorf("Expected 1 released task but found: %v", release)
+	}
+
+	// Make sure we scale up the number we release proportionally
+	fr.used = 999
+	release = bal.Balance()
+	if len(release) != 1 && release[0] == "1" {
+		t.Errorf("Expected 1 released task but found: %v", release)
+	}
+
+	//FIXME When #93 is fixed this test should break as CanClaim should actually
+	//      return false
+	if !bal.CanClaim("claimmepls") {
+		t.Errorf("Until #93 is fixed, CanClaim should always return true")
+	}
+}

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -110,8 +110,12 @@ type TestConsumerState struct {
 	Logger
 }
 
-func (tc *TestConsumerState) Tasks() []string {
-	return tc.Current
+func (tc *TestConsumerState) Tasks() []Task {
+	tasks := []Task{}
+	for _, id := range tc.Current {
+		tasks = append(tasks, newTask(id, nil))
+	}
+	return tasks
 }
 
 // Sleepy Balancer Tests
@@ -121,8 +125,12 @@ type sbCtx struct {
 	tasks []string
 }
 
-func (ctx *sbCtx) Tasks() []string {
-	return ctx.tasks
+func (ctx *sbCtx) Tasks() []Task {
+	tasks := []Task{}
+	for _, id := range ctx.tasks {
+		tasks = append(tasks, newTask(id, nil))
+	}
+	return tasks
 }
 func (ctx *sbCtx) Log(l LogLevel, v string, args ...interface{}) {
 	ctx.t.Logf(l.String()+" "+v, args)

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -4,21 +4,23 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+
+	"github.com/lytics/metafora"
 )
 
 // Consumer contains just the Metafora methods exposed by the HTTP
 // introspection endpoints.
 type Consumer interface {
 	Frozen() bool
-	Tasks() []string
+	Tasks() []metafora.Task
 }
 
 // InfoResponse is the JSON response marshalled by the MakeInfoHandler.
 type InfoResponse struct {
-	Frozen  bool      `json:"frozen"`
-	Node    string    `json:"node"`
-	Started time.Time `json:"started"`
-	Tasks   []string  `json:"tasks"`
+	Frozen  bool            `json:"frozen"`
+	Node    string          `json:"node"`
+	Started time.Time       `json:"started"`
+	Tasks   []metafora.Task `json:"tasks"`
 }
 
 // MakeInfoHandler returns an HTTP handler which can be added to an exposed

--- a/resreporter/mem_linux.go
+++ b/resreporter/mem_linux.go
@@ -30,6 +30,9 @@ func (memory) Used() (used uint64, total uint64) {
 	var buffered uint64
 	var free uint64
 	for s.Scan() {
+		if total > 0 && foundFree && foundCache && foundBuf {
+			break
+		}
 		if total == 0 {
 			if n, _ := fmt.Sscanf(s.Text(), "MemTotal:%d", &total); n == 1 {
 				continue

--- a/resreporter/mem_linux.go
+++ b/resreporter/mem_linux.go
@@ -1,0 +1,67 @@
+package resreporter
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+)
+
+const meminfo = "/proc/meminfo"
+
+var Memory = memory{}
+
+type memory struct{}
+
+func (memory) Used() (used uint64, total uint64) {
+	fd, err := os.Open(meminfo)
+	if err != nil {
+		//XXX Should this use metafora's logger somehow?
+		log.Printf("Error reading free memory via "+meminfo+": %v", err)
+
+		// Effectively disable the balancer since an error happened
+		return 0, 100
+	}
+	defer fd.Close()
+
+	s := bufio.NewScanner(fd)
+	foundFree, foundCache, foundBuf := false, false, false
+	var cache uint64
+	var buffered uint64
+	var free uint64
+	for s.Scan() {
+		if total == 0 {
+			if n, _ := fmt.Sscanf(s.Text(), "MemTotal:%d", &total); n == 1 {
+				continue
+			}
+		}
+		if foundFree {
+			if n, _ := fmt.Sscanf(s.Text(), "MemFree:%d", &free); n == 1 {
+				continue
+			}
+		}
+		if !foundCache {
+			if n, _ := fmt.Sscanf(s.Text(), "Cached:%d", &cache); n == 1 {
+				foundCache = true
+				continue
+			}
+		}
+		if !foundBuf {
+			if n, _ := fmt.Sscanf(s.Text(), "Buffers:%d", &buffered); n == 1 {
+				foundBuf = true
+				continue
+			}
+		}
+	}
+	if err := s.Err(); err != nil {
+		//XXX Should this use metafora's logger somehow?
+		log.Printf("Error reading free memory via "+meminfo+": %v", err)
+
+		// Effectively disable the balancer since an error happened
+		return 0, 100
+	}
+
+	return total - (free + buffered + cache), total
+}
+
+func (memory) String() string { return "kB" }

--- a/resreporter/mem_linux_test.go
+++ b/resreporter/mem_linux_test.go
@@ -1,0 +1,19 @@
+package resreporter_test
+
+import (
+	"testing"
+
+	"github.com/lytics/metafora/resreporter"
+)
+
+func TestMemReporter(t *testing.T) {
+	used, total := resreporter.Memory.Used()
+	t.Logf("Used: %d %s (%d mB)", used, resreporter.Memory, used/1024)
+	t.Logf("Total: %d %s (%d mB)", total, resreporter.Memory, total/1024)
+	if used == 0 && total == 100 {
+		t.Fatal("Memory reporter failed!")
+	}
+	if used > total {
+		t.Fatal("More memory used than available?!")
+	}
+}

--- a/slowtask_test.go
+++ b/slowtask_test.go
@@ -17,7 +17,11 @@ func (b *releaseAllBalancer) Init(c BalancerContext) {
 func (b *releaseAllBalancer) CanClaim(string) bool { return true }
 func (b *releaseAllBalancer) Balance() []string {
 	b.balances <- 1
-	return b.ctx.Tasks()
+	ids := []string{}
+	for _, task := range b.ctx.Tasks() {
+		ids = append(ids, task.ID())
+	}
+	return ids
 }
 
 func TestDoubleRelease(t *testing.T) {

--- a/task.go
+++ b/task.go
@@ -1,0 +1,67 @@
+package metafora
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+type Task interface {
+	ID() string
+	Started() time.Time
+	Stopped() time.Time
+	json.Marshaler
+}
+
+// task is the per-task state Metafora tracks internally.
+type task struct {
+	// handler on which Run and Stop are called
+	h Handler
+
+	// id of task to satisfy Task interface
+	id string
+
+	// stopL serializes calls to task.h.Stop() to make handler implementations
+	// easier/safer as well as guard stopped
+	stopL sync.Mutex
+
+	// when task was started and when Stop was first called
+	started time.Time
+	stopped time.Time
+}
+
+func newTask(id string, h Handler) *task {
+	return &task{id: id, h: h, started: time.Now()}
+}
+
+func (t *task) stop() {
+	t.stopL.Lock()
+	defer t.stopL.Unlock()
+	if t.stopped.IsZero() {
+		t.stopped = time.Now()
+	}
+	t.h.Stop()
+}
+
+func (t *task) ID() string         { return t.id }
+func (t *task) Started() time.Time { return t.started }
+func (t *task) Stopped() time.Time {
+	t.stopL.Lock()
+	defer t.stopL.Unlock()
+	return t.stopped
+}
+
+func (t *task) MarshalJSON() ([]byte, error) {
+	js := struct {
+		ID      string     `json:"id"`
+		Started time.Time  `json:"started"`
+		Stopped *time.Time `json:"stopped,omitempty"`
+	}{ID: t.id, Started: t.started}
+
+	// Only set stopped if it's non-zero
+	if s := t.Stopped(); !s.IsZero() {
+		js.Stopped = &s
+	}
+
+	return json.Marshal(&js)
+}


### PR DESCRIPTION
Minimum viable fix for *Balancer using system-level stats #44*

Unfortunately this includes a change to the Balancer interface to expose more metadata about tasks. It's not required for this feature, but I think it's generally useful.

## Change Summary

* Design ``ResourceBalancer`` as just the logic around a ``ResourceReporter`` (**please come up with a better name for that**). The balancer part just compares the reported resources against configurable thresholds ot make balancing decisions.
* Implement a ``Memory`` resource reporter **for Linux only.** I tried to find a cross platform solution, but my solution doesn't even take into account all the eccentricities of the Linux memory model (Committed and Swap are ignored!). Cross platform will have to be piecemeal unless somebody finds a good third party library (although I'm pretty happy that outside the etcd coordinator, we have 0 external deps).
* Move tiny ``metafora.go:runningTask`` struct to ``tasks.go:task`` struct and record start and stop times for tasks. The more task metadata we can expose to balancers (and logs!), the better decisions they can make. Hopefully we can expand this task in useful ways.
* Expose the ``task`` struct via the ``Task`` interface which is... a bit awkward... Sucks to include the MarshalJSON method in the interface. Seems really out of place.