### PR TITLE
Switch to a global logger instead of contextualized ones

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -12,14 +12,12 @@ const (
 )
 
 // BalancerContext is a limited interface exposed to Balancers from the
-// Consumer for access to logging and limited Consumer state.
+// Consumer for access to limited Consumer state.
 type BalancerContext interface {
 	// Tasks returns a sorted list of task IDs run by this Consumer. The Consumer
 	// stops task manipulations during claiming and balancing, so the list will
 	// be accurate unless a task naturally completes.
 	Tasks() []Task
-
-	Logger
 }
 
 // Balancer is the core task balancing interface. Without a master Metafora
@@ -114,7 +112,7 @@ func (e *FairBalancer) Balance() []string {
 	e.lastreleased = map[string]bool{}
 	current, err := e.clusterstate.NodeTaskCount()
 	if err != nil {
-		e.bc.Log(LogLevelWarn, "Error retrieving cluster state: %v", err)
+		Warnf("Error retrieving cluster state: %v", err)
 		return nil
 	}
 

--- a/balancer_res.go
+++ b/balancer_res.go
@@ -70,7 +70,7 @@ func (b *ResourceBalancer) CanClaim(string) bool {
 		//      cause a tight loop with the coordinator. Sleep longer than more
 		//      lightly loaded nodes.
 		dur := time.Duration(100+(threshold-b.claimLimit)) * time.Millisecond
-		b.ctx.Log(LogLevelInfo, "%d is over the claim limit of %d. Used %d of %d %s. Sleeping %s before claiming.",
+		Infof("%d is over the claim limit of %d. Used %d of %d %s. Sleeping %s before claiming.",
 			threshold, b.claimLimit, used, total, b.reporter, dur)
 		time.Sleep(dur)
 		return true
@@ -103,7 +103,7 @@ func (b *ResourceBalancer) Balance() []string {
 		return nil
 	}
 
-	b.ctx.Log(LogLevelInfo, "Releasing task %s (started %s) because %d > %d (%d of %d %s used)",
+	Infof("Releasing task %s (started %s) because %d > %d (%d of %d %s used)",
 		task.ID(), task.Started(), threshold, b.releaseLimit, used, total, b.reporter)
 	return []string{task.ID()}
 }

--- a/balancer_res_test.go
+++ b/balancer_res_test.go
@@ -26,7 +26,6 @@ func TestResourceBalancer(t *testing.T) {
 
 	ctx := &TestConsumerState{
 		Current: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"},
-		Logger:  LogT(t),
 	}
 	bal.Init(ctx)
 

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -19,7 +19,6 @@ func TestFairBalancerOneNode(t *testing.T) {
 
 	consumerstate := &TestConsumerState{
 		[]string{"1", "2", "3", "4", "5"},
-		LogT(t),
 	}
 
 	fb := NewDefaultFairBalancer("node1", clusterstate)
@@ -46,7 +45,6 @@ func TestFairBalanceOver(t *testing.T) {
 
 	consumerstate := &TestConsumerState{
 		[]string{"1", "2", "3", "4", "5"},
-		LogT(t),
 	}
 
 	fb := NewDefaultFairBalancer("node1", clusterstate)
@@ -74,7 +72,6 @@ func TestFairBalanceNothing(t *testing.T) {
 
 	consumerstate := &TestConsumerState{
 		[]string{"1", "2", "3", "4", "5"},
-		LogT(t),
 	}
 
 	fb := NewDefaultFairBalancer("node1", clusterstate)
@@ -107,7 +104,6 @@ func (ts *TestClusterState) NodeTaskCount() (map[string]int, error) {
 
 type TestConsumerState struct {
 	Current []string
-	Logger
 }
 
 func (tc *TestConsumerState) Tasks() []Task {

--- a/coordinator.go
+++ b/coordinator.go
@@ -9,7 +9,6 @@ type CoordinatorContext interface {
 	// Since this implies there is a window of time where the task is executing
 	// more than once, this is a sign of an unhealthy cluster.
 	Lost(taskID string)
-	Logger
 }
 
 // Coordinator is the core interface Metafora uses to discover, claim, and
@@ -49,12 +48,11 @@ type Coordinator interface {
 
 type coordinatorContext struct {
 	*Consumer
-	Logger
 }
 
 // Lost is a light wrapper around Coordinator.stopTask to make it suitable for
 // calling by Coordinator implementations via the CoordinatorContext interface.
 func (ctx *coordinatorContext) Lost(taskID string) {
-	ctx.Log(LogLevelError, "Lost task %s", taskID)
+	Errorf("Lost task %s", taskID)
 	ctx.stopTask(taskID)
 }

--- a/examples/koalemosd/main.go
+++ b/examples/koalemosd/main.go
@@ -13,10 +13,6 @@ import (
 	"github.com/lytics/metafora/m_etcd"
 )
 
-const lflags = log.Ldate | log.Lmicroseconds | log.Lshortfile
-
-var logger = log.New(os.Stdout, "", lflags)
-
 func main() {
 	mlvl := metafora.LogLevelInfo
 
@@ -40,6 +36,7 @@ func main() {
 	case "error":
 		mlvl = metafora.LogLevelError
 	}
+	metafora.SetLogLevel(mlvl)
 
 	hfunc := makeHandlerFunc(etcdc)
 	coord := m_etcd.NewEtcdCoordinator(*name, *namespace, etcdc).(*m_etcd.EtcdCoordinator)
@@ -48,7 +45,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error creating consumer: %v", err)
 	}
-	c.SetLogger(logger, mlvl)
 	log.Printf(
 		"Starting koalsmosd with etcd=%s; namespace=%s; name=%s; loglvl=%s",
 		*peers, *namespace, coord.NodeID, mlvl)

--- a/m_etcd/client_test.go
+++ b/m_etcd/client_test.go
@@ -52,7 +52,7 @@ func TestNodes(t *testing.T) {
 func TestSubmitTask(t *testing.T) {
 	eclient := newEtcdClient(t)
 
-	mclient := NewClientWithLogger(Namespace, eclient, testLogger{"metafora-client", t})
+	mclient := NewClient(Namespace, eclient)
 
 	if err := mclient.DeleteTask("testid1"); err != nil {
 		t.Logf("DeleteTask returned an error, which maybe ok.  Error:%v", err)

--- a/m_etcd/coordinator_test.go
+++ b/m_etcd/coordinator_test.go
@@ -86,7 +86,7 @@ func TestCoordinatorTC2(t *testing.T) {
 	result := make(chan error, 1)
 	testTasks := []string{"test-claiming-task0001", "test-claiming-task0002", "test-claiming-task0003"}
 
-	mclient := NewClientWithLogger(namespace, client, testLogger{"metafora-client1", t})
+	mclient := NewClient(namespace, client)
 
 	go func() {
 		//Watch blocks, so we need to test it in its own go routine.
@@ -144,7 +144,7 @@ func TestCoordinatorTC3(t *testing.T) {
 	test_finished := make(chan bool)
 	testTasks := []string{"test-claiming-task0001", "test-claiming-task0002", "test-claiming-task0003"}
 
-	mclient := NewClientWithLogger(namespace, client, testLogger{"metafora-client1", t})
+	mclient := NewClient(namespace, client)
 
 	startATaskWatcher := func() {
 		//Watch blocks, so we need to test it in its own go routine.
@@ -212,7 +212,7 @@ func TestCoordinatorTC4(t *testing.T) {
 	watchOk := make(chan bool)
 	task := "testtask4"
 
-	mclient := NewClientWithLogger(namespace, client, testLogger{"metafora-client1", t})
+	mclient := NewClient(namespace, client)
 
 	err := mclient.SubmitTask(task)
 	if err != nil {
@@ -277,7 +277,7 @@ func TestClaimRefreshExpire(t *testing.T) {
 	}
 	coord1ResultChannel := make(chan string)
 
-	mclient := NewClientWithLogger(namespace, client, testLogger{"client", t})
+	mclient := NewClient(namespace, client)
 	task := "testclaimrefreshexpire"
 
 	go func() {

--- a/metafora_test.go
+++ b/metafora_test.go
@@ -1,9 +1,21 @@
 package metafora
 
 import (
+	"flag"
 	"testing"
 	"time"
 )
+
+func init() {
+	flag.Parse()
+	if !testing.Verbose() {
+		SetLogger(testlogger{})
+	}
+}
+
+type testlogger struct{}
+
+func (testlogger) Output(int, string) error { return nil }
 
 // Handler/Consumer test
 

--- a/resreporter/mem_linux.go
+++ b/resreporter/mem_linux.go
@@ -3,8 +3,9 @@ package resreporter
 import (
 	"bufio"
 	"fmt"
-	"log"
 	"os"
+
+	"github.com/lytics/metafora"
 )
 
 const meminfo = "/proc/meminfo"
@@ -16,8 +17,7 @@ type memory struct{}
 func (memory) Used() (used uint64, total uint64) {
 	fd, err := os.Open(meminfo)
 	if err != nil {
-		//XXX Should this use metafora's logger somehow?
-		log.Printf("Error reading free memory via "+meminfo+": %v", err)
+		metafora.Errorf("Error reading free memory via "+meminfo+": %v", err)
 
 		// Effectively disable the balancer since an error happened
 		return 0, 100
@@ -57,8 +57,7 @@ func (memory) Used() (used uint64, total uint64) {
 		}
 	}
 	if err := s.Err(); err != nil {
-		//XXX Should this use metafora's logger somehow?
-		log.Printf("Error reading free memory via "+meminfo+": %v", err)
+		metafora.Errorf("Error reading free memory via "+meminfo+": %v", err)
 
 		// Effectively disable the balancer since an error happened
 		return 0, 100

--- a/util_test.go
+++ b/util_test.go
@@ -1,29 +1,12 @@
 package metafora
 
-import (
-	"errors"
-	"fmt"
-	"testing"
-)
+import "errors"
 
 //TODO Move out into a testutil package for other packages to use. The problem
 //is that existing metafora tests would have to be moved to the metafora_test
 //package which means no manipulating unexported globals like balance jitter.
 
 var bal = &DumbBalancer{}
-
-type testLogger struct {
-	t *testing.T
-}
-
-func (l *testLogger) Log(ll LogLevel, v string, args ...interface{}) {
-	l.t.Logf("[%s] %s", ll, fmt.Sprintf(v, args...))
-}
-
-// LogT creates a Metafora compatiable Logger that logs to t.Logf.
-func LogT(t *testing.T) Logger {
-	return &testLogger{t: t}
-}
 
 type TestCoord struct {
 	Tasks    chan string // will be returned in order, "" indicates return an error


### PR DESCRIPTION
Pros:

* Compatible with *log.Logger or
* Simpler API for Metafora components.
* Smaller context interfaces.
* Contextualized logger was flaky and displayed `<autogenerated>`
  instead of the filename due to calldepth being wrong.
* Logger can be reused by apps or set by apps. (Less
  opinionated/specialized)

Cons:

* Can't set the logger to a `testing.T` for tests and get parallel
  per-test logs. Seems like a small sacrifice.
* Larger global API.