### PR TITLE
Fix stack depth in new logger

### DIFF
--- a/examples/koalemosd/handler.go
+++ b/examples/koalemosd/handler.go
@@ -86,10 +86,14 @@ func (h *shellHandler) Run(taskID string) (done bool) {
 	if err := cmd.Wait(); err != nil {
 		if err.(*exec.ExitError).Sys().(syscall.WaitStatus).Signal() == os.Interrupt {
 			h.log("Stopping")
+			// Not done!
+			done = false
 		} else {
 			h.log("Exited with error: %v", err)
 			done = true // don't retry commands that error'd
 		}
+	} else {
+		done = true
 	}
 
 	// Only delete task if command is done

--- a/logger.go
+++ b/logger.go
@@ -90,7 +90,7 @@ func (l *logger) log(lvl LogLevel, v ...interface{}) {
 		return
 	}
 
-	l.l.Output(2, fmt.Sprintf("[%s] %s", lvl, fmt.Sprint(v...)))
+	l.l.Output(3, fmt.Sprintf("[%s] %s", lvl, fmt.Sprint(v...)))
 }
 
 func (l *logger) logf(lvl LogLevel, format string, v ...interface{}) {
@@ -102,5 +102,5 @@ func (l *logger) logf(lvl LogLevel, format string, v ...interface{}) {
 		return
 	}
 
-	l.l.Output(2, fmt.Sprintf("[%s] %s", lvl, fmt.Sprintf(format, v...)))
+	l.l.Output(3, fmt.Sprintf("[%s] %s", lvl, fmt.Sprintf(format, v...)))
 }


### PR DESCRIPTION
Also improve the logging in koalemosd as it's the easiest way to peek at what "real" log output is going to look like.

The stack depth was off-by-one in the log output which made every log line appear to be from "logger.go". The reason it was off is because I added the debug/info/warn/error helper methods in PR #106