### PR TITLE
CanClaim rejects tasks for a period of time.

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -29,28 +29,32 @@ type Balancer interface {
 	// be useful for CanClaim and Balance implementations.
 	Init(BalancerContext)
 
-	// CanClaim should return true if the consumer should accept a task. No new
-	// tasks will be claimed while CanClaim is called.
-	CanClaim(taskID string) bool
+	// CanClaim should return true if the consumer should accept a task.
+	//
+	// When denying a claim by returning false, CanClaim should return the time
+	// at which to reconsider the task for claiming.
+	CanClaim(taskID string) (ignoreUntil time.Time, claim bool)
 
-	// Balance should return the list of Task IDs that should be released. No new
-	// tasks will be claimed during balancing. The criteria used to determine
-	// which tasks should be released is left up to the implementation.
+	// Balance should return the list of Task IDs that should be released. The
+	// criteria used to determine which tasks should be released is left up to
+	// the implementation.
 	Balance() (release []string)
 }
 
 // DumbBalancer is the simplest possible balancer implementation which simply
-// accepts all tasks.
-type DumbBalancer struct{}
+// accepts all tasks. Since it has no state a single global instance exists.
+var DumbBalancer = dumbBalancer{}
+
+type dumbBalancer struct{}
 
 // Init does nothing.
-func (*DumbBalancer) Init(BalancerContext) {}
+func (dumbBalancer) Init(BalancerContext) {}
 
 // CanClaim always returns true.
-func (*DumbBalancer) CanClaim(string) bool { return true }
+func (dumbBalancer) CanClaim(string) (time.Time, bool) { return time.Time{}, true }
 
 // Balance never returns any tasks to balance.
-func (*DumbBalancer) Balance() []string { return nil }
+func (dumbBalancer) Balance() []string { return nil }
 
 // Provides information about the cluster to be used by FairBalancer
 type ClusterState interface {
@@ -72,7 +76,6 @@ func NewDefaultFairBalancerWithThreshold(nodeid string, cs ClusterState, thresho
 		nodeid:           nodeid,
 		clusterstate:     cs,
 		releaseThreshold: threshold,
-		lastreleased:     map[string]bool{},
 	}
 }
 
@@ -89,27 +92,28 @@ type FairBalancer struct {
 	clusterstate ClusterState
 
 	releaseThreshold float64
-
-	lastreleased map[string]bool
+	delay            time.Duration
 }
 
 func (e *FairBalancer) Init(s BalancerContext) {
 	e.bc = s
 }
 
-// CanClaim will claim all tasks, but will add a sleep to block claiming
-// released tasks in order to give other nodes a chance to claim them first
-func (e *FairBalancer) CanClaim(taskid string) bool {
-	if e.lastreleased[taskid] {
-		time.Sleep(500 * time.Millisecond)
+// CanClaim will claim any task if this node wasn't over the task threshold
+// during the last rebalance. If it was over the threshold claims will be
+// delayed proportionally.
+func (e *FairBalancer) CanClaim(taskid string) (time.Time, bool) {
+	if e.delay == 0 {
+		return time.Time{}, true
 	}
-	return true
+	return time.Now().Add(e.delay), false
 }
 
 // Balance releases tasks if this node has 120% more tasks than the average
 // node in the cluster.
 func (e *FairBalancer) Balance() []string {
-	e.lastreleased = map[string]bool{}
+	// Reset delay
+	e.delay = 0
 	current, err := e.clusterstate.NodeTaskCount()
 	if err != nil {
 		Warnf("Error retrieving cluster state: %v", err)
@@ -127,9 +131,9 @@ func (e *FairBalancer) Balance() []string {
 	for len(releasetasks) < shouldrelease {
 		tid := nodetasks[random.Intn(len(nodetasks))].ID()
 		releasetasks = append(releasetasks, tid)
-		e.lastreleased[tid] = true
 	}
 
+	e.delay = time.Duration(len(releasetasks)) * time.Second
 	return releasetasks
 }
 

--- a/balancer.go
+++ b/balancer.go
@@ -11,6 +11,11 @@ const (
 	defaultThreshold float64 = 1.2
 )
 
+// NoDelay is simply the zero value for time and meant to be a more meaningful
+// value for CanClaim methods to return instead of initializing a new empty
+// time struct.
+var NoDelay = time.Time{}
+
 // BalancerContext is a limited interface exposed to Balancers from the
 // Consumer for access to limited Consumer state.
 type BalancerContext interface {
@@ -51,7 +56,7 @@ type dumbBalancer struct{}
 func (dumbBalancer) Init(BalancerContext) {}
 
 // CanClaim always returns true.
-func (dumbBalancer) CanClaim(string) (time.Time, bool) { return time.Time{}, true }
+func (dumbBalancer) CanClaim(string) (time.Time, bool) { return NoDelay, true }
 
 // Balance never returns any tasks to balance.
 func (dumbBalancer) Balance() []string { return nil }
@@ -104,7 +109,7 @@ func (e *FairBalancer) Init(s BalancerContext) {
 // delayed proportionally.
 func (e *FairBalancer) CanClaim(taskid string) (time.Time, bool) {
 	if e.delay == 0 {
-		return time.Time{}, true
+		return NoDelay, true
 	}
 	return time.Now().Add(e.delay), false
 }

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -24,7 +24,7 @@ func TestFairBalancerOneNode(t *testing.T) {
 	fb := NewDefaultFairBalancer("node1", clusterstate)
 	fb.Init(consumerstate)
 
-	if !fb.CanClaim("23") {
+	if _, ok := fb.CanClaim("23"); !ok {
 		t.Fatal("Expected claim to be true")
 	}
 
@@ -50,7 +50,7 @@ func TestFairBalanceOver(t *testing.T) {
 	fb := NewDefaultFairBalancer("node1", clusterstate)
 	fb.Init(consumerstate)
 
-	if !fb.CanClaim("23") {
+	if _, ok := fb.CanClaim("23"); !ok {
 		t.Fatal("Expected claim to be true")
 	}
 
@@ -77,7 +77,7 @@ func TestFairBalanceNothing(t *testing.T) {
 	fb := NewDefaultFairBalancer("node1", clusterstate)
 	fb.Init(consumerstate)
 
-	if !fb.CanClaim("23") {
+	if _, ok := fb.CanClaim("23"); !ok {
 		t.Fatal("Expected claim to be true")
 	}
 

--- a/embedded/embedded_test.go
+++ b/embedded/embedded_test.go
@@ -20,7 +20,7 @@ func TestEmbedded(t *testing.T) {
 	})
 
 	coord, client := NewEmbeddedPair("testnode")
-	runner, _ := metafora.NewConsumer(coord, thfunc, &metafora.DumbBalancer{})
+	runner, _ := metafora.NewConsumer(coord, thfunc, metafora.DumbBalancer)
 
 	go runner.Run()
 
@@ -66,7 +66,7 @@ func TestEmbeddedShutdown(t *testing.T) {
 	})
 
 	coord, client := NewEmbeddedPair("testnode")
-	runner, _ := metafora.NewConsumer(coord, thfunc, &metafora.DumbBalancer{})
+	runner, _ := metafora.NewConsumer(coord, thfunc, metafora.DumbBalancer)
 
 	go runner.Run()
 

--- a/httputil/httputil_test.go
+++ b/httputil/httputil_test.go
@@ -15,9 +15,9 @@ type tc struct {
 }
 
 func (*tc) Init(metafora.CoordinatorContext) error { return nil }
-func (c *tc) Watch() (string, error) {
+func (c *tc) Watch(chan<- string) error {
 	<-c.stop
-	return "", nil
+	return nil
 }
 func (c *tc) Claim(string) bool { return false }
 func (c *tc) Release(string)    {}
@@ -31,7 +31,7 @@ func (c *tc) Close() { close(c.stop) }
 func TestMakeInfoHandler(t *testing.T) {
 	t.Parallel()
 
-	c, _ := metafora.NewConsumer(&tc{stop: make(chan bool)}, nil, &metafora.DumbBalancer{})
+	c, _ := metafora.NewConsumer(&tc{stop: make(chan bool)}, nil, metafora.DumbBalancer)
 	defer c.Shutdown()
 	name := "test-name"
 	now := time.Now().Truncate(time.Second)

--- a/ignore.go
+++ b/ignore.go
@@ -1,0 +1,119 @@
+package metafora
+
+import (
+	"container/heap"
+	"sync"
+	"time"
+)
+
+type ignoremgr struct {
+	incoming chan *timetask
+	mu       *sync.RWMutex
+	ignores  map[string]struct{}
+}
+
+func ignorer(tasks chan<- string, stop <-chan struct{}) *ignoremgr {
+	im := &ignoremgr{mu: &sync.RWMutex{}, ignores: make(map[string]struct{}), incoming: make(chan *timetask)}
+	go im.monitor(tasks, stop)
+	return im
+}
+
+func (im *ignoremgr) add(taskID string, until time.Time) {
+	// short circuit ignores that have already elapsed
+	if until.Before(time.Now()) {
+		return
+	}
+	im.mu.Lock()
+	im.ignores[taskID] = struct{}{}
+	im.incoming <- &timetask{time: until, task: taskID}
+	im.mu.Unlock()
+}
+
+func (im *ignoremgr) ignored(taskID string) (ignored bool) {
+	im.mu.RLock()
+	_, ok := im.ignores[taskID]
+	im.mu.RUnlock()
+
+	return ok
+}
+
+func (im *ignoremgr) monitor(tasks chan<- string, stop <-chan struct{}) {
+	times := timeheap{}
+	heap.Init(&times)
+	var next *timetask
+	for {
+		if times.Len() > 0 {
+			// Get next ignore from the ignore heap
+			next = heap.Pop(&times).(*timetask)
+		} else {
+			// No ignores! Wait for one to come in or an exit signal
+			select {
+			case <-stop:
+				return
+			case newtask := <-im.incoming:
+				next = newtask
+			}
+		}
+
+		timer := time.NewTimer(next.time.Sub(time.Now()))
+
+		select {
+		case newtask := <-im.incoming:
+			heap.Push(&times, newtask)
+			heap.Push(&times, next)
+			timer.Stop()
+		case <-timer.C:
+			// Ignore expired, remove the entry
+			im.mu.Lock()
+			delete(im.ignores, next.task)
+			im.mu.Unlock()
+
+			// Notify the consumer
+			select {
+			case tasks <- next.task:
+			case <-stop:
+				return
+			}
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (im *ignoremgr) all() []string {
+	im.mu.RLock()
+	defer im.mu.RUnlock()
+	ignores := make([]string, len(im.ignores))
+	i := 0
+	for k := range im.ignores {
+		ignores[i] = k
+		i++
+	}
+	return ignores
+}
+
+type timetask struct {
+	time time.Time
+	task string
+}
+
+// timeheap is a min-heap of time/task tuples sorted by time.
+type timeheap []*timetask
+
+func (h timeheap) Len() int           { return len(h) }
+func (h timeheap) Less(i, j int) bool { return h[i].time.Before(h[j].time) }
+func (h timeheap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *timeheap) Push(x interface{}) {
+	// Push and Pop use pointer receivers because they modify the slice's length,
+	// not just its contents.
+	*h = append(*h, x.(*timetask))
+}
+
+func (h *timeheap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/ignore.go
+++ b/ignore.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+// ignoremgr handles ignoring tasks and sending them back to the consumer once
+// their ignore deadline is reached.
 type ignoremgr struct {
 	incoming chan *timetask
 	mu       *sync.RWMutex

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -1,0 +1,49 @@
+package metafora
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIgnore(t *testing.T) {
+	t.Parallel()
+	out := make(chan string)
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// Create ignorer
+	im := ignorer(out, stop)
+
+	// Ignore task for 200ms. Yes this is racy. Might need to bump deadline.
+	deadline1 := time.Now().Add(200 * time.Millisecond)
+	im.add("1", deadline1)
+
+	// Ensure it's ignored
+	if !im.ignored("1") {
+		t.Fatal("test task should have been ignored but wasn't")
+	}
+
+	// Ignore task for 10ms to make sure tasks are returned in order (they aren't
+	// *guaranteed* to be in order since adds and evictions are concurrent)
+	deadline2 := time.Now().Add(10 * time.Millisecond)
+	im.add("2", deadline2)
+
+	// Wait for the first eviction
+	eviction := <-out
+	if eviction != "2" {
+		t.Fatal("Expected 2 to be evicted before 1")
+	}
+	now := time.Now()
+	if now.Before(deadline2) {
+		t.Fatal("First eviction happened too soon: %s < %s", now, deadline2)
+	}
+
+	eviction = <-out
+	if eviction != "1" {
+		t.Fatal("Expected 1 to be evicted second, found ", eviction)
+	}
+	now = time.Now()
+	if now.Before(deadline1) {
+		t.Fatalf("First eviction happened too soon: %s < %s", now, deadline1)
+	}
+}

--- a/m_etcd/helpers_test.go
+++ b/m_etcd/helpers_test.go
@@ -42,7 +42,7 @@ func newEtcdClient(t *testing.T) *etcd.Client {
 }
 
 // setupEtcd should be used for all etcd integration tests. It handles the following tasks:
-//  * Skip testsif ETCDTESTS is unset
+//  * Skip tests if ETCDTESTS is unset
 //  * Create and return an etcd client
 //  * Create and return an initial etcd coordinator
 func setupEtcd(t *testing.T) (*EtcdCoordinator, *etcd.Client) {

--- a/m_etcd/taskmgr.go
+++ b/m_etcd/taskmgr.go
@@ -164,22 +164,3 @@ func (m *taskManager) remove(taskID string, done bool) {
 		}
 	}
 }
-
-// stop blocks until all refreshers have exited.
-func (m *taskManager) stop() {
-	func() {
-		m.taskL.Lock()
-		defer m.taskL.Unlock()
-		for _, states := range m.tasks {
-			select {
-			case <-states.release:
-				// already stopping
-			case <-states.done:
-				// already stopping
-			default:
-				close(states.release)
-			}
-		}
-	}()
-	m.wg.Wait()
-}

--- a/slowtask_test.go
+++ b/slowtask_test.go
@@ -14,7 +14,7 @@ func (b *releaseAllBalancer) Init(c BalancerContext) {
 	b.ctx = c
 	b.balances = make(chan int)
 }
-func (b *releaseAllBalancer) CanClaim(string) bool { return true }
+func (b *releaseAllBalancer) CanClaim(string) (time.Time, bool) { return time.Time{}, true }
 func (b *releaseAllBalancer) Balance() []string {
 	b.balances <- 1
 	ids := []string{}

--- a/slowtask_test.go
+++ b/slowtask_test.go
@@ -14,7 +14,7 @@ func (b *releaseAllBalancer) Init(c BalancerContext) {
 	b.ctx = c
 	b.balances = make(chan int)
 }
-func (b *releaseAllBalancer) CanClaim(string) (time.Time, bool) { return time.Time{}, true }
+func (b *releaseAllBalancer) CanClaim(string) (time.Time, bool) { return NoDelay, true }
 func (b *releaseAllBalancer) Balance() []string {
 	b.balances <- 1
 	ids := []string{}

--- a/util_test.go
+++ b/util_test.go
@@ -6,13 +6,12 @@ import "errors"
 //is that existing metafora tests would have to be moved to the metafora_test
 //package which means no manipulating unexported globals like balance jitter.
 
-var bal = &DumbBalancer{}
-
 type TestCoord struct {
 	Tasks    chan string // will be returned in order, "" indicates return an error
 	Commands chan Command
 	Releases chan string
 	Dones    chan string
+	closed   chan bool
 }
 
 func NewTestCoord() *TestCoord {
@@ -21,23 +20,38 @@ func NewTestCoord() *TestCoord {
 		Commands: make(chan Command, 10),
 		Releases: make(chan string, 10),
 		Dones:    make(chan string, 10),
+		closed:   make(chan bool),
 	}
 }
 
 func (*TestCoord) Init(CoordinatorContext) error { return nil }
 func (*TestCoord) Claim(string) bool             { return true }
-func (*TestCoord) Close()                        { return }
+func (c *TestCoord) Close()                      { close(c.closed) }
 func (c *TestCoord) Release(task string)         { c.Releases <- task }
 func (c *TestCoord) Done(task string)            { c.Dones <- task }
 
-// Watch returns tasks from the Tasks channel unless an empty string is sent.
+// Watch sends tasks from the Tasks channel unless an empty string is sent.
 // Then an error is returned.
-func (c *TestCoord) Watch() (string, error) {
-	task := <-c.Tasks
-	if task == "" {
-		return "", errors.New("test error")
+func (c *TestCoord) Watch(out chan<- string) error {
+	task := ""
+	for {
+		select {
+		case task = <-c.Tasks:
+			Debugf("TestCoord recvd: %s", task)
+			if task == "" {
+				return errors.New("test error")
+			}
+		case <-c.closed:
+			return nil
+		}
+		select {
+		case out <- task:
+			Debugf("TestCoord sent: %s", task)
+		case <-c.closed:
+			return nil
+		}
 	}
-	return task, nil
+	return nil
 }
 
 // Command returns commands from the Commands channel unless a nil is sent.


### PR DESCRIPTION
**API breaks: Coordinator and Balancer**

This change makes Metafora look uglier in the abstract but actually
handle operational realities better. The existing CanClaim interface
didn't reflect reality: if it rejected a task the Coordinator's Watch
method might just continue returning only that task forever...and in a
tight loop no less! There was no way for the Coordinator's Watch and
Balancer to communicate (unless they implemented shared state outside
the Consumer which sounds really tricky to get right).

This design makes Coordinator.Watch stream claimable tasks back to the
Consumer. The Consumer checks an ignore-list before even calling
Balancer.CanClaim. If a task isn't ignored, CanClaim can cause it to be
ignored until a deadline.

Once the deadline is up *the Consumer handles the task as if it came
from the Coordinator.* This means it gives the Balancer's CanClaim
method another chance to reject it and everything.

Even if `CanClaim` doesn't reject the task again, the task probably
can't be claimed anyway because another node claimed it ages ago.
That's ok. This design trades off being optimally efficient for safety:
it never rejects a task forever (possibly orphaning it), and it never
bypasses the Balancer.

Fixes #93

Errors returned by `Coordinator.Watch` or `Coordinator.Command` are now
**fatal**. Nowhere in our logs could I find an instance of them failing
(even in our flaky staging environment).  I think it's fine to expect
the Coordinator to be resilient and only return errors when *it*
determines it cannot continue to function safely.

Fixes #71

Also makes `DumbBalancer` a singleton because it's silly not to.