### PR TITLE
Statemachine improvements

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lytics/metafora"
+	"github.com/lytics/metafora/statemachine"
 )
 
 // Consumer contains just the Metafora methods exposed by the HTTP
@@ -16,12 +17,24 @@ type Consumer interface {
 	String() string
 }
 
+type stateMachine interface {
+	State() (*statemachine.State, time.Time)
+}
+
+type Task struct {
+	ID       string     `json:"id"`
+	Started  time.Time  `json:"started"`
+	Stopped  *time.Time `json:"stopped,omitempty"`
+	State    string     `json:"state,omitempty"`
+	Modified *time.Time `json:"modified,omitempty"`
+}
+
 // InfoResponse is the JSON response marshalled by the MakeInfoHandler.
 type InfoResponse struct {
-	Frozen  bool            `json:"frozen"`
-	Name    string          `json:"name"`
-	Started time.Time       `json:"started"`
-	Tasks   []metafora.Task `json:"tasks"`
+	Frozen  bool      `json:"frozen"`
+	Name    string    `json:"name"`
+	Started time.Time `json:"started"`
+	Tasks   []Task    `json:"tasks"`
 }
 
 // MakeInfoHandler returns an HTTP handler which can be added to an exposed
@@ -29,12 +42,33 @@ type InfoResponse struct {
 // node introspection.
 func MakeInfoHandler(c Consumer, started time.Time) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(&InfoResponse{
+		tasks := c.Tasks()
+		resp := InfoResponse{
 			Frozen:  c.Frozen(),
 			Name:    c.String(),
 			Started: started,
-			Tasks:   c.Tasks(),
-		})
+			Tasks:   make([]Task, len(tasks)),
+		}
+		for i, task := range tasks {
+			resp.Tasks[i] = Task{
+				ID:      task.ID(),
+				Started: task.Started(),
+			}
+
+			// Set stopped if it's non-zero
+			stopped := task.Stopped()
+			if !stopped.IsZero() {
+				resp.Tasks[i].Stopped = &stopped
+			}
+
+			// Expose state if it exists
+			if sh, ok := task.Handler().(stateMachine); ok {
+				s, ts := sh.State()
+				resp.Tasks[i].State = s.String()
+				resp.Tasks[i].Modified = &ts
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(&resp)
 	}
 }

--- a/m_etcd/client.go
+++ b/m_etcd/client.go
@@ -69,7 +69,7 @@ func (mc *mclient) SubmitCommand(node string, command metafora.Command) error {
 		metafora.Errorf("Error submitting command: %s to node: %s", command, node)
 		return err
 	}
-	metafora.Debugf("Submitted command: %s to node: %s", command, node)
+	metafora.Debugf("Submitted command: %s to node: %s", string(body), node)
 	return nil
 }
 

--- a/m_etcd/coordinator.go
+++ b/m_etcd/coordinator.go
@@ -319,7 +319,7 @@ startWatch:
 func (ec *EtcdCoordinator) parseTask(resp *etcd.Response) (task string, ok bool) {
 	// Sanity check / test path invariant
 	if !strings.HasPrefix(resp.Node.Key, ec.taskPath) {
-		metafora.Errorf("Received task from outside task path: %s", resp.Node.Key)
+		metafora.Errorf("%s received task from outside task path: %s", ec.name, resp.Node.Key)
 		return "", false
 	}
 
@@ -331,17 +331,17 @@ func (ec *EtcdCoordinator) parseTask(resp *etcd.Response) (task string, ok bool)
 		// Make sure it's not already claimed before returning it
 		for _, n := range resp.Node.Nodes {
 			if strings.HasSuffix(n.Key, OwnerMarker) {
-				metafora.Debugf("Ignoring task as it's already claimed: %s", parts[2])
+				metafora.Debugf("%s ignoring task as it's already claimed: %s", ec.name, parts[2])
 				return "", false
 			}
 		}
-		metafora.Debugf("Received new task: %s", parts[2])
+		metafora.Debugf("%s received new task: %s", ec.name, parts[2])
 		return parts[2], true
 	}
 
 	// If a claim key is removed, try to claim the task
 	if releaseActions[resp.Action] && len(parts) == 4 && parts[3] == OwnerMarker {
-		metafora.Debugf("Received released task: %s", parts[2])
+		metafora.Debugf("%s received released task: %s", ec.name, parts[2])
 		return parts[2], true
 	}
 

--- a/m_etcd/coordinator.go
+++ b/m_etcd/coordinator.go
@@ -130,7 +130,7 @@ func NewEtcdCoordinator(nodeID, namespace string, client *etcd.Client) metafora.
 	return &EtcdCoordinator{
 		Client:    client,
 		namespace: namespace,
-		name:      "etcd:/" + nodeID + namespace,
+		name:      "etcd:" + namespace + "/" + nodeID,
 
 		taskPath: path.Join(namespace, TasksPath),
 		ClaimTTL: ClaimTTL, //default to the package constant, but allow it to be overwritten

--- a/m_etcd/integration_test.go
+++ b/m_etcd/integration_test.go
@@ -1,10 +1,11 @@
 package m_etcd_test
 
 import (
-	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/coreos/go-etcd/etcd"
 	"github.com/lytics/metafora"
 	"github.com/lytics/metafora/m_etcd"
 	"github.com/lytics/metafora/m_etcd/testutil"
@@ -17,94 +18,152 @@ func TestNew(t *testing.T) {
 	etcdc := testutil.NewEtcdClient(t)
 
 	const recursive = true
-	etcdc.Delete("testnew1", recursive)
-	etcdc.Delete("testnew2", recursive)
+	etcdc.Delete("test-a", recursive)
+	etcdc.Delete("test-b", recursive)
 
-	// Start 2 simple consumers in different namespaces
-	h1 := func(_ string, cmds <-chan statemachine.Message) statemachine.Message {
-		return <-cmds
+	h := func(tid string, cmds <-chan statemachine.Message) statemachine.Message {
+		cmd := <-cmds
+		if tid == "error-test" {
+			return statemachine.Message{Code: statemachine.Error, Err: errors.New("error-test")}
+		}
+		return cmd
 	}
-	coord1, hf1, bal1 := m_etcd.New("node1", "testnew1", etcdc, h1)
-	cons1, err := metafora.NewConsumer(coord1, hf1, bal1)
-	if err != nil {
-		t.Fatalf("Error creating consumer 1: %v", err)
-	}
-	done1 := make(chan bool)
-	go func() {
-		defer close(done1)
-		cons1.Run()
-	}()
 
-	h2 := func(_ string, cmds <-chan statemachine.Message) statemachine.Message {
-		return <-cmds
+	newC := func(name, ns string) *metafora.Consumer {
+		coord, hf, bal := m_etcd.New(name, ns, etcdc, h)
+		cons, err := metafora.NewConsumer(coord, hf, bal)
+		if err != nil {
+			t.Fatalf("Error creating consumer %s:%s: %v", ns, name, err)
+		}
+		go cons.Run()
+		return cons
 	}
-	coord2, hf2, bal2 := m_etcd.New("node1", "testnew2", etcdc, h2)
-	cons2, err := metafora.NewConsumer(coord2, hf2, bal2)
-	if err != nil {
-		t.Fatalf("Error creating consumer 1: %v", err)
-	}
-	done2 := make(chan bool)
-	go func() {
-		defer close(done2)
-		cons2.Run()
-	}()
+	// Start 4 consumers, 2 per namespace
+	cons1a := newC("node1", "test-a")
+	cons2a := newC("node2", "test-a")
+	cons1b := newC("node1", "test-b")
+	cons2b := newC("node2", "test-b")
 
 	// Create clients and start some tests
-	cli1 := m_etcd.NewClient("testnew1", etcdc)
-	cli2 := m_etcd.NewClient("testnew2", etcdc)
+	cliA := m_etcd.NewClient("test-a", etcdc)
+	cliB := m_etcd.NewClient("test-b", etcdc)
 
-	if err := cli1.SubmitTask("task1"); err != nil {
-		t.Fatalf("Error submitting task1: %v", err)
+	if err := cliA.SubmitTask("task1"); err != nil {
+		t.Fatalf("Error submitting task1 to a: %v", err)
 	}
-	if err := cli2.SubmitTask("task2"); err != nil {
-		t.Fatalf("Error submitting task2: %v", err)
+	if err := cliB.SubmitTask("task1"); err != nil {
+		t.Fatalf("Error submitting task1 to b: %v", err)
 	}
 
 	// Give consumers a bit to pick up tasks
 	time.Sleep(250 * time.Millisecond)
 
-	{
-		tasks := cons1.Tasks()
-		if len(tasks) != 1 || tasks[0].ID() != "task1" || !tasks[0].Stopped().IsZero() {
-			buf, _ := json.Marshal(tasks)
-			t.Fatalf("Expected task1 to be running but found: %s", string(buf))
+	assertRunning := func(tid string, cons ...*metafora.Consumer) {
+		found := false
+		for _, c := range cons {
+			tasks := c.Tasks()
+			if len(tasks) > 0 && found {
+				t.Fatal("Task already found running but another task is running on a different consumer")
+			}
+			if len(tasks) > 1 {
+				t.Fatalf("Expected at most 1 task, but found: %d", len(tasks))
+			}
+			if len(tasks) == 1 && tasks[0].ID() == tid {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("Could not find task=%q", tid)
 		}
 	}
 
+	assertRunning("task1", cons1a, cons2a)
+	assertRunning("task1", cons1b, cons2b)
+
+	// Kill task1 in A
 	{
-		tasks := cons2.Tasks()
-		if len(tasks) != 1 || tasks[0].ID() != "task2" || !tasks[0].Stopped().IsZero() {
-			buf, _ := json.Marshal(tasks)
-			t.Fatalf("Expected task2 to be running but found: %s", string(buf))
+		cmdr := m_etcd.NewCommander("test-a", etcdc)
+		if err := cmdr.Send("task1", statemachine.Message{Code: statemachine.Kill}); err != nil {
+			t.Fatalf("Error sending kill to task1: %v", err)
+		}
+		time.Sleep(250 * time.Millisecond)
+
+		for _, c := range []*metafora.Consumer{cons1a, cons2a} {
+			tasks := c.Tasks()
+			if len(tasks) != 0 {
+				t.Fatalf("Expected no tasks but found: %d", len(tasks))
+			}
 		}
 	}
 
-	// Kill task1
-	cmdr := m_etcd.NewCommander("testnew1", etcdc)
-	if err := cmdr.Send("task1", statemachine.Message{Code: statemachine.Kill}); err != nil {
-		t.Fatalf("Error sending kill to task1: %v", err)
-	}
-	time.Sleep(250 * time.Millisecond)
-
+	// Submit a bunch of tasks to A
 	{
-		tasks := cons1.Tasks()
-		if len(tasks) != 0 {
-			buf, _ := json.Marshal(tasks)
-			t.Fatalf("Expected no tasks but found: %s", string(buf))
+		tasks := map[string]int{"task2": 1, "task3": 1, "task4": 1, "task5": 1, "task6": 1, "task7": 1}
+		for tid := range tasks {
+			if err := cliA.SubmitTask(tid); err != nil {
+				t.Fatalf("Error submitting task=%q to a: %v", tid, err)
+			}
+		}
+
+		// Give them time to start
+		time.Sleep(500 * time.Millisecond)
+
+		// Ensure they're balanced
+		if err := cliA.SubmitCommand("node1", metafora.CommandBalance()); err != nil {
+			t.Fatalf("Error submitting balance command to cons1a: %v", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+		if err := cliA.SubmitCommand("node2", metafora.CommandBalance()); err != nil {
+			t.Fatalf("Error submitting balance command to cons1a: %v", err)
+		}
+
+		a1tasks := cons1a.Tasks()
+		a2tasks := cons2a.Tasks()
+		for _, task := range a1tasks {
+			metafora.Debug("A1: ", task.ID(), " - ", task.Stopped().IsZero())
+		}
+		for _, task := range a2tasks {
+			metafora.Debug("A2: ", task.ID(), " - ", task.Stopped().IsZero())
+		}
+		time.Sleep(500 * time.Millisecond)
+
+		a1tasks = cons1a.Tasks()
+		a2tasks = cons2a.Tasks()
+		if len(a1tasks) < 2 || len(a1tasks) > 4 || len(a2tasks) < 2 || len(a2tasks) > 4 {
+			t.Fatalf("Namespace A isn't fairly balanced: node1: %d; node2: %d", len(a1tasks), len(a2tasks))
+		}
+
+		// Shutting down a consumer should migrate all tasks to the other
+		cons1a.Shutdown()
+		time.Sleep(500 * time.Millisecond)
+
+		a2tasks = cons2a.Tasks()
+		if len(a2tasks) != len(tasks) {
+			t.Fatalf("Consumer 2a should have received all %d tasks but only has %d.", len(tasks), len(a2tasks))
 		}
 	}
 
-	{
-		tasks := cons2.Tasks()
-		if len(tasks) != 1 || tasks[0].ID() != "task2" || !tasks[0].Stopped().IsZero() {
-			buf, _ := json.Marshal(tasks)
-			t.Fatalf("Expected task2 to be running but found: %s", string(buf))
-		}
+	// Shutdown
+	cons2a.Shutdown()
+	cons1b.Shutdown()
+	cons2b.Shutdown()
+
+	// Make sure everything is cleaned up
+	respA, err := etcdc.Get("/test-a/tasks", true, true)
+	if err != nil {
+		t.Fatalf("Error getting tasks from etcd: %v", err)
+	}
+	respB, err := etcdc.Get("/test-b/tasks", true, true)
+	if err != nil {
+		t.Fatalf("Error getting tasks from etcd: %v", err)
 	}
 
-	// Shutdown both consumers
-	cons1.Shutdown()
-	cons2.Shutdown()
-	<-done1
-	<-done2
+	nodes := []*etcd.Node{}
+	nodes = append(nodes, respA.Node.Nodes...)
+	nodes = append(nodes, respB.Node.Nodes...)
+	for _, node := range nodes {
+		if len(node.Nodes) > 0 {
+			t.Fatalf("%s has %d nodes. First key: %s", node.Key, len(node.Nodes), node.Nodes[0].Key)
+		}
+	}
 }

--- a/m_etcd/statestore.go
+++ b/m_etcd/statestore.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/lytics/metafora"
 	"github.com/lytics/metafora/statemachine"
 )
 
@@ -31,12 +32,12 @@ func NewStateStore(namespace string, etcdc *etcd.Client) statemachine.StateStore
 // Load retrieves the given task's state from etcd or stores and returns
 // Runnable if no state exists.
 func (s *stateStore) Load(taskID string) (*statemachine.State, error) {
-	const recursive = false
-	const sort = false
-	resp, err := s.c.Get(s.path, recursive, sort)
+	const notrecursive = false
+	const nosort = false
+	resp, err := s.c.Get(path.Join(s.path, taskID), notrecursive, nosort)
 	if err != nil {
 		if ee, ok := err.(*etcd.EtcdError); ok && ee.ErrorCode == EcodeKeyNotFound {
-			// No existing key, default to Runnable
+			metafora.Infof("task=%q has no existing state, default to Runnable", taskID)
 			state := &statemachine.State{Code: statemachine.Runnable}
 			if err := s.Store(taskID, state); err != nil {
 				return nil, err

--- a/statemachine/README.md
+++ b/statemachine/README.md
@@ -9,7 +9,7 @@ Metafora task handlers.
 * Per task state machine; task may intercept commands
 * Flexible state store (see `StateStore` interface)
 * Flexible command sending/receiving (see `Commander`, `CommandListener`, or
-  [the etcd implementation](../m_etcd/commander.go).
+  [the etcd implementation](../m_etcd/commander.go)).
 * Flexible error handling with builtin retry logic (see
   [`errors.go`](errors.go)).
 * States: Runnable, Paused, Sleeping, Fault, Completed, Failed, Killed

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -8,16 +8,18 @@ import (
 	"github.com/lytics/metafora"
 )
 
+// StateCode is the actual state key. The State struct adds additional metadata
+// related to certain StateCodes.
 type StateCode string
 
 const (
 	Runnable  StateCode = "runnable"  // Scheduled
-	Sleeping            = "sleeping"  // Scheduled, not running until time has elapsed
-	Completed           = "completed" // Terminal, not scheduled
-	Killed              = "killed"    // Terminal, not scheduled
-	Failed              = "failed"    // Terminal, not scheduled
-	Fault               = "fault"     // Scheduled, in error handling / retry logic
-	Paused              = "paused"    // Scheduled, not running
+	Sleeping  StateCode = "sleeping"  // Scheduled, not running until time has elapsed
+	Completed StateCode = "completed" // Terminal, not scheduled
+	Killed    StateCode = "killed"    // Terminal, not scheduled
+	Failed    StateCode = "failed"    // Terminal, not scheduled
+	Fault     StateCode = "fault"     // Scheduled, in error handling / retry logic
+	Paused    StateCode = "paused"    // Scheduled, not running
 )
 
 // Terminal states will never run and cannot transition to a non-terminal
@@ -112,12 +114,12 @@ type MessageCode string
 
 const (
 	Run        MessageCode = "run"
-	Sleep                  = "sleep"
-	Pause                  = "pause"
-	Kill                   = "kill"
-	Error                  = "error"
-	Complete               = "complete"
-	Checkpoint             = "checkpoint"
+	Sleep      MessageCode = "sleep"
+	Pause      MessageCode = "pause"
+	Kill       MessageCode = "kill"
+	Error      MessageCode = "error"
+	Complete   MessageCode = "complete"
+	Checkpoint MessageCode = "checkpoint"
 
 	// Special event which triggers state machine to exit without transitioning
 	// between states.

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -140,7 +140,7 @@ func (t Transition) String() string {
 
 var (
 	// Rules is the state transition table.
-	Rules = []Transition{
+	Rules = [...]Transition{
 		// Runnable can transition to anything
 		{Event: Checkpoint, From: Runnable, To: Runnable},
 		{Event: Release, From: Runnable, To: Runnable},

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -417,7 +417,13 @@ func apply(cur *State, m Message) (*State, bool) {
 	for _, trans := range Rules {
 		if trans.Event == m.Code && trans.From == cur.Code {
 			metafora.Debugf("Transitioned %s", trans)
-			return &State{Code: trans.To, Until: m.Until}, true
+			if m.Err != nil {
+				// Append errors from message
+				cur.Errors = append(cur.Errors, Err{Time: time.Now(), Err: m.Err.Error()})
+			}
+
+			// New State + Message's Until + Combined Errors
+			return &State{Code: trans.To, Until: m.Until, Errors: cur.Errors}, true
 		}
 	}
 	return cur, false

--- a/statemachine/statemachine_test.go
+++ b/statemachine/statemachine_test.go
@@ -83,7 +83,10 @@ func TestRules(t *testing.T) {
 				until := time.Now().Add(10 * time.Millisecond)
 				msg.Until = &until
 			}
-			if err := cmdr.Send("test", Message{Code: trans.Event}); err != nil {
+			if trans.Event == Error {
+				msg.Err = errors.New("test")
+			}
+			if err := cmdr.Send("test", msg); err != nil {
 				t.Fatalf("Error sending message %s: %v", trans.Event, err)
 			}
 		}

--- a/task.go
+++ b/task.go
@@ -10,7 +10,7 @@ type Task interface {
 	ID() string
 	Started() time.Time
 	Stopped() time.Time
-	json.Marshaler
+	Handler() Handler
 }
 
 // task is the per-task state Metafora tracks internally.
@@ -44,6 +44,7 @@ func (t *task) stop() {
 }
 
 func (t *task) ID() string         { return t.id }
+func (t *task) Handler() Handler   { return t.h }
 func (t *task) Started() time.Time { return t.started }
 func (t *task) Stopped() time.Time {
 	t.stopL.Lock()


### PR DESCRIPTION
Sorry for the mega-PR! I'll try to point out the discrete bits:

* Expose state via http handler for handlers that support it: [`httputil`](https://github.com/lytics/metafora/pull/114/files#diff-1b9c09fd51c2c282d47901bb1b888645)
* Improve coordinator/consumer name logging all over the place
* Fix shutdown/release race in `taskmgr` & `Consumer.Shutdown`
* [Drop invalid commands](https://github.com/lytics/metafora/pull/114/files#diff-490e54f090d107c4b07c3da6958589beR253) - Previously invalid commands would cause the handler to go into an error state. It seemed wrong to put the *handler* in an error state when it was the *sender* of the command that made the mistake.