### PR TITLE
Handle panics in etcd client on watch

### DIFF
--- a/m_etcd/commander.go
+++ b/m_etcd/commander.go
@@ -144,10 +144,15 @@ startWatch:
 
 watchLoop:
 	for {
-		rr, err := c.cli.RawWatch(c.path, index, notrecursive, nil, c.stop)
+		rr, err := protectedRawWatch(c.cli, c.path, index, notrecursive, nil, c.stop)
 		if err != nil {
 			if err == etcd.ErrWatchStoppedByUser {
 				return
+			}
+			// This is probably a canceled request panic
+			// Wait a little bit, then continue as normal
+			if ispanic(err) {
+				continue
 			}
 			metafora.Errorf("Error watching %s - sending error to stateful handler: %v", c.path, err)
 			c.sendErr(err)

--- a/m_etcd/commander.go
+++ b/m_etcd/commander.go
@@ -151,6 +151,7 @@ watchLoop:
 			}
 			// This is probably a canceled request panic
 			// Wait a little bit, then continue as normal
+			// Can be removed after Go 1.5 is released
 			if ispanic(err) {
 				continue
 			}

--- a/m_etcd/coordinator.go
+++ b/m_etcd/coordinator.go
@@ -489,6 +489,7 @@ func (ec *EtcdCoordinator) watch(path string, index uint64, stop chan bool) (*et
 
 			// This is probably a canceled request panic
 			// Wait a little bit, then continue as normal
+			// Can be removed after Go 1.5 is released
 			if ispanic(err) {
 				time.Sleep(250 * time.Millisecond)
 				continue


### PR DESCRIPTION
Bug in etcd/Go causes an occasional panic: https://github.com/coreos/go-etcd/issues/197

This fix adds a recover around watches, with a short pause and resume.

This is fixed in Go 1.5, and we should remove this hack when it is available; forever retrying on a panic is terrifying.