### PR TITLE
Sleep after successful claims to encourage fairness

### DIFF
--- a/m_etcd/coordinator.go
+++ b/m_etcd/coordinator.go
@@ -278,8 +278,6 @@ func (ec *EtcdCoordinator) refreshBy(c *etcd.Client, deadline time.Time) (err er
 // Watch streams tasks from etcd watches or GETs until Close is called or etcd
 // is unreachable (in which case an error is returned).
 func (ec *EtcdCoordinator) Watch(out chan<- string) error {
-	const sorted = true
-	const recursive = true
 	var index uint64
 
 	client, err := newEtcdClient(ec.hosts)
@@ -297,7 +295,9 @@ startWatch:
 		}
 
 		// Get existing tasks
-		resp, err := client.Get(ec.taskPath, sorted, recursive)
+		const notsorted = false
+		const recursive = true
+		resp, err := client.Get(ec.taskPath, notsorted, recursive)
 		if err != nil {
 			metafora.Errorf("%s Error getting the existing tasks: %v", ec.taskPath, err)
 			return err

--- a/metafora.go
+++ b/metafora.go
@@ -337,6 +337,11 @@ func (c *Consumer) claimed(taskID string) {
 		delete(c.running, taskID)
 		c.runL.Unlock()
 	}()
+
+	// Pause slightly after a successful claim to give starting tasks some
+	// breathing room and to bias the next claim toward a node that lost this
+	// one.
+	time.Sleep(10 * time.Millisecond)
 }
 
 // runTask executes a handler's Run method and recovers from panic()s.


### PR DESCRIPTION
It was observed when restarting a cluster that if a node won the first
claim it would win *all* subsequent claims as claiming and failing to
claim take nearly identical resources.

This slows down the "winner" to try to encourage a fairly balanced
cluster.

While balancers are probably a better place to do this, the consumer
should prevent pathological behaviors like we were seeing, so I think a
slight sleep in the core consumer is fine.