### PR TITLE
When fair balancing, having <= 1 task is always fair

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -119,13 +119,14 @@ func (e *FairBalancer) CanClaim(taskid string) (time.Time, bool) {
 func (e *FairBalancer) Balance() []string {
 	nodetasks := e.bc.Tasks()
 
+	// Reset delay
+	e.delay = 0
+
 	// If local tasks <= 1 this node should never rebalance
 	if len(nodetasks) < 2 {
 		return nil
 	}
 
-	// Reset delay
-	e.delay = 0
 	current, err := e.clusterstate.NodeTaskCount()
 	if err != nil {
 		Warnf("Error retrieving cluster state: %v", err)

--- a/balancer.go
+++ b/balancer.go
@@ -117,6 +117,13 @@ func (e *FairBalancer) CanClaim(taskid string) (time.Time, bool) {
 // Balance releases tasks if this node has 120% more tasks than the average
 // node in the cluster.
 func (e *FairBalancer) Balance() []string {
+	nodetasks := e.bc.Tasks()
+
+	// If local tasks <= 1 this node should never rebalance
+	if len(nodetasks) < 2 {
+		return nil
+	}
+
 	// Reset delay
 	e.delay = 0
 	current, err := e.clusterstate.NodeTaskCount()
@@ -134,7 +141,6 @@ func (e *FairBalancer) Balance() []string {
 	releaseset := make(map[string]struct{}, shouldrelease)
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
-	nodetasks := e.bc.Tasks()
 	for len(releasetasks) < shouldrelease {
 		tid := nodetasks[random.Intn(len(nodetasks))].ID()
 		if _, ok := releaseset[tid]; !ok {


### PR DESCRIPTION
This fixes a fun bug where only 1 task exists in a cluster. Each node
will claim it and then try to release it to be fair until no one can
claim it.