### PR TITLE
Fix race when adding ignore during shutdown

### DIFF
--- a/ignore_test.go
+++ b/ignore_test.go
@@ -15,7 +15,7 @@ func TestIgnore(t *testing.T) {
 	im := ignorer(out, stop)
 
 	// Ignore task for 200ms. Yes this is racy. Might need to bump deadline.
-	deadline1 := time.Now().Add(300 * time.Millisecond)
+	deadline1 := time.Now().Add(200 * time.Millisecond)
 	im.add("1", deadline1)
 
 	// Ensure it's ignored

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -15,7 +15,7 @@ func TestIgnore(t *testing.T) {
 	im := ignorer(out, stop)
 
 	// Ignore task for 200ms. Yes this is racy. Might need to bump deadline.
-	deadline1 := time.Now().Add(200 * time.Millisecond)
+	deadline1 := time.Now().Add(300 * time.Millisecond)
 	im.add("1", deadline1)
 
 	// Ensure it's ignored


### PR DESCRIPTION
Previously if Consumer.Shutdown was called while the Consumer was adding
an ignored task, the ignore manager's send of the task to the
ignored-task-monitor would block forever -- preventing shutdown of the
consumer.

This change allows the sending of the ignored task to the monitor to
abort if a shutdown has been initiated. Note that this leaves the
ignoremgr's map and timeheap in an inconcistent state during shutdowns,
but there's no case in which they're used during shutdown so it's safe.