### PR TITLE
Make stateful handler command chan very defensive

### DIFF
--- a/statemachine/run_test.go
+++ b/statemachine/run_test.go
@@ -1,0 +1,52 @@
+package statemachine
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCommandBlackhole is meant to demonstrate what happens if a
+// StatefulHandler implementation receives commands in a goroutine that lives
+// past the SatefulHandler func exiting. This is a very easy bug to write, so
+// defensive code was added to prevent the leaked goroutine from "stealing"
+// commands meant for other states (Paused or Sleeping being the two states
+// that absolutely need to accept commands).
+//
+// This test breaking isn't necessarily the sign of a bug. It may just mean
+// we've decided to remove the defensive code protecting against such errors in
+// which case this test should be removed as well.
+func TestCommandBlackhole(t *testing.T) {
+	t.Parallel()
+	stop := make(chan bool)
+	rdy := make(chan int, 1)
+	defer close(stop)
+
+	f := func(_ string, c <-chan Message) Message {
+		go func() {
+			rdy <- 1
+			select {
+			case <-c:
+				t.Log("Intercepted!")
+			case <-stop:
+				return
+			}
+		}()
+		return Message{}
+	}
+	cmds := make(chan Message)
+
+	// Ignore the return message, the point is to make sure it doesn't intercept
+	// further commands.
+	run(f, "test-task", cmds)
+
+	go func() { cmds <- Message{Code: Run} }()
+
+	<-rdy
+
+	select {
+	case <-cmds:
+		// Yay! command wasn't intercepted by leaked goroutine!
+	case <-time.After(time.Second):
+		t.Fatalf("Command was intercepted by leaked goroutine.")
+	}
+}

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -387,7 +387,26 @@ func run(f StatefulHandler, tid string, cmd <-chan Message) (m Message) {
 			m = Message{Code: Error, Err: fmt.Errorf("panic: %v", r)}
 		}
 	}()
-	m = f(tid, cmd)
+
+	// Defensive code to give handlers a *copy* of the command chan. That way if
+	// a handler keeps receiving on the command chan in a goroutine past the
+	// handler's lifetime it doesn't intercept commands intended for the
+	// statemachine.
+	internalcmd := make(chan Message)
+	stopped := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case c := <-cmd:
+				internalcmd <- c
+			case <-stopped:
+				return
+			}
+		}
+	}()
+	defer close(stopped)
+
+	m = f(tid, internalcmd)
 	return m
 }
 

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -406,8 +406,7 @@ func run(f StatefulHandler, tid string, cmd <-chan Message) (m Message) {
 	}()
 	defer close(stopped)
 
-	m = f(tid, internalcmd)
-	return m
+	return f(tid, internalcmd)
 }
 
 // Stop sends a Release message to the state machine through the command chan.


### PR DESCRIPTION
I don't like this code, but that doesn't mean it's not a good idea. It's
just very easy for a handler to accidently orphan a goroutine that
receives commands. That effectively steals commands from e.g. sleep's
select cases.

A better solution might be a totally different API for sending commands
to tasks (perhaps a Command(m Message) method for handlers to implement.