### PR TITLE
Switch task ID to  Task interface throughout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+cover.out
 
 *.orig
 *.swp

--- a/Documentation/etcd.md
+++ b/Documentation/etcd.md
@@ -21,6 +21,7 @@ that implementing Metafora with etcd in your own work system is quick and easy.
     │
     ├── tasks
     │   └── <task_id>
+    │       ├── props          JSON value (optional)
     │       └── owner          Ephemeral, JSON value
     │
     ├── state                  Optional, only if using state store
@@ -49,6 +50,16 @@ The JSON format is:
 ```
 
 Note that Metafora does not handle task parameters or configuration.
+
+#### Task Properties
+
+Optionally tasks may have a properties key with a JSON value. The value must be
+immutable for the life of the task.
+
+Users may set a custom `NewTask` function on their `EtcdCoordinator` in order
+to unmarshal properties into a custom struct. The struct must implement the
+`metafora.Task` interface and code that wishes to use implementation specific
+methods or fields will have to type assert.
 
 ### Node Commands
 

--- a/balancer_res.go
+++ b/balancer_res.go
@@ -91,19 +91,19 @@ func (b *ResourceBalancer) Balance() []string {
 	}
 
 	// Release the oldest task that isn't already stopping
-	var task Task
+	var oldest RunningTask
 	for _, t := range b.ctx.Tasks() {
-		if t.Stopped().IsZero() && (task == nil || task.Started().After(t.Started())) {
-			task = t
+		if t.Stopped().IsZero() && (oldest == nil || oldest.Started().After(t.Started())) {
+			oldest = t
 		}
 	}
 
 	// No tasks or all tasks are stopping, don't bother rebalancing
-	if task == nil {
+	if oldest == nil {
 		return nil
 	}
 
 	Infof("Releasing task %s (started %s) because %d > %d (%d of %d %s used)",
-		task.ID(), task.Started(), threshold, b.releaseLimit, used, total, b.reporter)
-	return []string{task.ID()}
+		oldest.Task().ID(), oldest.Started(), threshold, b.releaseLimit, used, total, b.reporter)
+	return []string{oldest.Task().ID()}
 }

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -24,7 +24,7 @@ func TestFairBalancerOneNode(t *testing.T) {
 	fb := NewDefaultFairBalancer("node1", clusterstate)
 	fb.Init(consumerstate)
 
-	if _, ok := fb.CanClaim("23"); !ok {
+	if _, ok := fb.CanClaim(testTask{"23"}); !ok {
 		t.Fatal("Expected claim to be true")
 	}
 
@@ -50,7 +50,7 @@ func TestFairBalanceOver(t *testing.T) {
 	fb := NewDefaultFairBalancer("node1", clusterstate)
 	fb.Init(consumerstate)
 
-	if _, ok := fb.CanClaim("23"); !ok {
+	if _, ok := fb.CanClaim(testTask{"23"}); !ok {
 		t.Fatal("Expected claim to be true")
 	}
 
@@ -77,7 +77,7 @@ func TestFairBalanceNothing(t *testing.T) {
 	fb := NewDefaultFairBalancer("node1", clusterstate)
 	fb.Init(consumerstate)
 
-	if _, ok := fb.CanClaim("23"); !ok {
+	if _, ok := fb.CanClaim(testTask{"23"}); !ok {
 		t.Fatal("Expected claim to be true")
 	}
 
@@ -88,6 +88,12 @@ func TestFairBalanceNothing(t *testing.T) {
 	}
 
 }
+
+type testTask struct {
+	id string
+}
+
+func (t testTask) ID() string { return t.id }
 
 type TestClusterState struct {
 	Current map[string]int
@@ -106,10 +112,10 @@ type TestConsumerState struct {
 	Current []string
 }
 
-func (tc *TestConsumerState) Tasks() []Task {
-	tasks := []Task{}
+func (tc *TestConsumerState) Tasks() []RunningTask {
+	tasks := []RunningTask{}
 	for _, id := range tc.Current {
-		tasks = append(tasks, newTask(id, nil))
+		tasks = append(tasks, newTask(testTask{id}, nil))
 	}
 	return tasks
 }
@@ -121,10 +127,10 @@ type sbCtx struct {
 	tasks []string
 }
 
-func (ctx *sbCtx) Tasks() []Task {
-	tasks := []Task{}
+func (ctx *sbCtx) Tasks() []RunningTask {
+	tasks := []RunningTask{}
 	for _, id := range ctx.tasks {
-		tasks = append(tasks, newTask(id, nil))
+		tasks = append(tasks, newTask(testTask{id}, nil))
 	}
 	return tasks
 }

--- a/client.go
+++ b/client.go
@@ -2,7 +2,7 @@ package metafora
 
 type Client interface {
 	// SubmitTask submits a task to the system, the task id must be unique.
-	SubmitTask(taskId string) error
+	SubmitTask(Task) error
 
 	// Delete a task
 	DeleteTask(taskId string) error

--- a/embedded/client.go
+++ b/embedded/client.go
@@ -2,18 +2,18 @@ package embedded
 
 import "github.com/lytics/metafora"
 
-func NewEmbeddedClient(taskchan chan string, cmdchan chan *NodeCommand, nodechan chan []string) metafora.Client {
+func NewEmbeddedClient(taskchan chan metafora.Task, cmdchan chan *NodeCommand, nodechan chan []string) metafora.Client {
 	return &EmbeddedClient{taskchan, cmdchan, nodechan}
 }
 
 type EmbeddedClient struct {
-	taskchan chan<- string
+	taskchan chan<- metafora.Task
 	cmdchan  chan<- *NodeCommand
 	nodechan <-chan []string
 }
 
-func (ec *EmbeddedClient) SubmitTask(taskid string) error {
-	ec.taskchan <- taskid
+func (ec *EmbeddedClient) SubmitTask(t metafora.Task) error {
+	ec.taskchan <- t
 	return nil
 }
 

--- a/embedded/coordinator.go
+++ b/embedded/coordinator.go
@@ -6,7 +6,7 @@ import (
 	"github.com/lytics/metafora"
 )
 
-func NewEmbeddedCoordinator(nodeid string, taskchan chan string, cmdchan chan *NodeCommand, nodechan chan []string) metafora.Coordinator {
+func NewEmbeddedCoordinator(nodeid string, taskchan chan metafora.Task, cmdchan chan *NodeCommand, nodechan chan []string) metafora.Coordinator {
 	e := &EmbeddedCoordinator{inchan: taskchan, cmdchan: cmdchan, stopchan: make(chan struct{}), nodechan: nodechan}
 	// HACK - need to respond to node requests, assuming a single coordinator/client pair
 	go func() {
@@ -26,7 +26,7 @@ func NewEmbeddedCoordinator(nodeid string, taskchan chan string, cmdchan chan *N
 type EmbeddedCoordinator struct {
 	nodeid   string
 	ctx      metafora.CoordinatorContext
-	inchan   chan string
+	inchan   chan metafora.Task
 	cmdchan  chan *NodeCommand
 	nodechan chan<- []string
 	stopchan chan struct{}
@@ -37,7 +37,7 @@ func (e *EmbeddedCoordinator) Init(c metafora.CoordinatorContext) error {
 	return nil
 }
 
-func (e *EmbeddedCoordinator) Watch(out chan<- string) error {
+func (e *EmbeddedCoordinator) Watch(out chan<- metafora.Task) error {
 	for {
 		// wait for incoming tasks
 		select {
@@ -56,23 +56,23 @@ func (e *EmbeddedCoordinator) Watch(out chan<- string) error {
 	}
 }
 
-func (e *EmbeddedCoordinator) Claim(taskID string) bool {
+func (e *EmbeddedCoordinator) Claim(task metafora.Task) bool {
 	// We recieved on a channel, we are the only ones to pull that value
 	return true
 }
 
-func (e *EmbeddedCoordinator) Release(taskID string) {
+func (e *EmbeddedCoordinator) Release(task metafora.Task) {
 	// Releasing should be async to avoid deadlocks (and better reflect the
 	// behavior of "real" coordinators)
 	go func() {
 		select {
-		case e.inchan <- taskID:
+		case e.inchan <- task:
 		case <-e.stopchan:
 		}
 	}()
 }
 
-func (e *EmbeddedCoordinator) Done(taskID string) {}
+func (e *EmbeddedCoordinator) Done(task metafora.Task) {}
 
 func (e *EmbeddedCoordinator) Command() (metafora.Command, error) {
 	select {

--- a/embedded/embedded_test.go
+++ b/embedded/embedded_test.go
@@ -13,9 +13,9 @@ func TestEmbedded(t *testing.T) {
 	tc := newTestCounter()
 	adds := make(chan string, 4)
 
-	thfunc := metafora.SimpleHandler(func(id string, _ <-chan bool) bool {
-		tc.Add(id)
-		adds <- id
+	thfunc := metafora.SimpleHandler(func(task metafora.Task, _ <-chan bool) bool {
+		tc.Add(task.ID())
+		adds <- task.ID()
 		return true
 	})
 
@@ -25,7 +25,7 @@ func TestEmbedded(t *testing.T) {
 	go runner.Run()
 
 	for _, taskid := range []string{"one", "two", "three", "four"} {
-		err := client.SubmitTask(taskid)
+		err := client.SubmitTask(&Task{TID: taskid})
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -54,7 +54,7 @@ func TestEmbeddedShutdown(t *testing.T) {
 	const n = 4
 	runs := make(chan int, n)
 	stops := make(chan int, n)
-	thfunc := metafora.SimpleHandler(func(id string, s <-chan bool) bool {
+	thfunc := metafora.SimpleHandler(func(_ metafora.Task, s <-chan bool) bool {
 		runs <- 1
 		select {
 		case <-s:
@@ -75,7 +75,7 @@ func TestEmbeddedShutdown(t *testing.T) {
 
 	// submit tasks
 	for _, taskid := range tasks {
-		err := client.SubmitTask(taskid)
+		err := client.SubmitTask(&Task{TID: taskid})
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}

--- a/embedded/statestore.go
+++ b/embedded/statestore.go
@@ -3,6 +3,7 @@ package embedded
 import (
 	"sync"
 
+	"github.com/lytics/metafora"
 	"github.com/lytics/metafora/statemachine"
 )
 
@@ -32,21 +33,21 @@ func NewStateStore() statemachine.StateStore {
 	}
 }
 
-func (s *StateStore) Load(tid string) (*statemachine.State, error) {
+func (s *StateStore) Load(task metafora.Task) (*statemachine.State, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	state, ok := s.store[tid]
+	state, ok := s.store[task.ID()]
 	if !ok {
 		return &statemachine.State{Code: statemachine.Runnable}, nil
 	}
 	return state, nil
 }
 
-func (s *StateStore) Store(tid string, state *statemachine.State) error {
+func (s *StateStore) Store(task metafora.Task, state *statemachine.State) error {
 	s.mu.Lock()
-	s.store[tid] = state
+	s.store[task.ID()] = state
 	s.mu.Unlock()
-	stored := StateChanged{TaskID: tid, State: state}
+	stored := StateChanged{TaskID: task.ID(), State: state}
 	select {
 	case s.Stored <- stored:
 	default:

--- a/embedded/task.go
+++ b/embedded/task.go
@@ -1,0 +1,8 @@
+package embedded
+
+// Task is the embedded coorindator's metafora.Task implemenation.
+type Task struct {
+	TID string
+}
+
+func (t *Task) ID() string { return t.TID }

--- a/embedded/util.go
+++ b/embedded/util.go
@@ -9,7 +9,7 @@ type NodeCommand struct {
 
 // Returns a connected client/coordinator pair for embedded/testing use
 func NewEmbeddedPair(nodeid string) (metafora.Coordinator, metafora.Client) {
-	taskchan := make(chan string)
+	taskchan := make(chan metafora.Task)
 	cmdchan := make(chan *NodeCommand)
 	nodechan := make(chan []string, 1)
 

--- a/examples/koalemos/task.go
+++ b/examples/koalemos/task.go
@@ -1,0 +1,18 @@
+package koalemos
+
+import "github.com/lytics/metafora"
+
+// Not necessary; just here to illustrate the point of this struct
+var _ metafora.Task = (*Task)(nil)
+
+type Task struct {
+	id   string
+	Args []string
+}
+
+func (t *Task) ID() string { return t.id }
+
+// NewTask creates a new task given an ID.
+func NewTask(id string) *Task {
+	return &Task{id: id}
+}

--- a/examples/koalemosctl/main.go
+++ b/examples/koalemosctl/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/lytics/metafora/examples/koalemos"
 	"github.com/lytics/metafora/m_etcd"
 )
 
@@ -33,24 +33,15 @@ func main() {
 	}
 
 	rand.Seed(time.Now().UnixNano())
-	taskID := fmt.Sprintf("%x", rand.Int63())
 
-	// First create the task body
-	body, err := json.Marshal(&struct{ Args []string }{Args: args})
-	if err != nil {
-		fmt.Printf("Error marshaling task body: %v", err)
-		os.Exit(3)
-	}
-	if _, err := ec.Set("/koalemos-tasks/"+taskID, string(body), 30*24*60*60); err != nil {
-		fmt.Printf("Error creating task body: %v", err)
-		os.Exit(4)
-	}
+	task := koalemos.NewTask(fmt.Sprintf("%x", rand.Int63()))
+	task.Args = args
 
 	// Finally create the task for metafora
 	mc := m_etcd.NewClient(*namespace, hosts)
-	if err := mc.SubmitTask(taskID); err != nil {
-		fmt.Println("Error submitting task:", taskID)
-		os.Exit(5)
+	if err := mc.SubmitTask(task); err != nil {
+		fmt.Println("Error submitting task:", task.ID())
+		os.Exit(2)
 	}
-	fmt.Println(taskID)
+	fmt.Println(task.ID())
 }

--- a/handler.go
+++ b/handler.go
@@ -34,28 +34,28 @@ type Handler interface {
 // are called concurrently, any state used by both should be initialized in the
 // HandlerFunc. Since Handlerfunc is uninterruptable, only the minimum amount
 // of work necessary to initialize a handler should be done.
-type HandlerFunc func(taskID string) Handler
+type HandlerFunc func(Task) Handler
 
 // SimpleHander creates a HandlerFunc for a simple function that accepts a stop
 // channel. The channel will be closed when Stop is called.
-func SimpleHandler(f func(taskID string, stop <-chan bool) bool) HandlerFunc {
-	return func(taskID string) Handler {
+func SimpleHandler(f func(t Task, stop <-chan bool) bool) HandlerFunc {
+	return func(t Task) Handler {
 		return &simpleHandler{
-			taskID: taskID,
-			stop:   make(chan bool),
-			f:      f,
+			task: t,
+			stop: make(chan bool),
+			f:    f,
 		}
 	}
 }
 
 type simpleHandler struct {
-	taskID string
-	stop   chan bool
-	f      func(string, <-chan bool) bool
+	task Task
+	stop chan bool
+	f    func(Task, <-chan bool) bool
 }
 
 func (h *simpleHandler) Run() bool {
-	return h.f(h.taskID, h.stop)
+	return h.f(h.task, h.stop)
 }
 
 func (h *simpleHandler) Stop() {

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -13,7 +13,7 @@ import (
 // introspection endpoints.
 type Consumer interface {
 	Frozen() bool
-	Tasks() []metafora.Task
+	Tasks() []metafora.RunningTask
 	String() string
 }
 
@@ -51,7 +51,7 @@ func MakeInfoHandler(c Consumer, started time.Time) http.HandlerFunc {
 		}
 		for i, task := range tasks {
 			resp.Tasks[i] = Task{
-				ID:      task.ID(),
+				ID:      task.Task().ID(),
 				Started: task.Started(),
 			}
 

--- a/httputil/httputil_test.go
+++ b/httputil/httputil_test.go
@@ -15,13 +15,13 @@ type tc struct {
 }
 
 func (*tc) Init(metafora.CoordinatorContext) error { return nil }
-func (c *tc) Watch(chan<- string) error {
+func (c *tc) Watch(chan<- metafora.Task) error {
 	<-c.stop
 	return nil
 }
-func (c *tc) Claim(string) bool { return false }
-func (c *tc) Release(string)    {}
-func (c *tc) Done(string)       {}
+func (c *tc) Claim(metafora.Task) bool { return false }
+func (c *tc) Release(metafora.Task)    {}
+func (c *tc) Done(metafora.Task)       {}
 func (c *tc) Command() (metafora.Command, error) {
 	<-c.stop
 	return nil, nil

--- a/m_etcd/balancer_test.go
+++ b/m_etcd/balancer_test.go
@@ -9,15 +9,14 @@ import (
 
 func TestFairBalancer(t *testing.T) {
 	coord1, hosts := setupEtcd(t)
-	c2, _ := NewEtcdCoordinator("node2", namespace, hosts)
-	coord2 := c2.(*EtcdCoordinator)
+	coord2, _ := NewEtcdCoordinator("node2", namespace, hosts)
 
 	cli := NewClient(namespace, hosts)
 
-	h := metafora.SimpleHandler(func(task string, stop <-chan bool) bool {
-		metafora.Debugf("Starting %s", task)
+	h := metafora.SimpleHandler(func(task metafora.Task, stop <-chan bool) bool {
+		metafora.Debugf("Starting %s", task.ID())
 		<-stop
-		metafora.Debugf("Stopping %s", task)
+		metafora.Debugf("Stopping %s", task.ID())
 		return false // never done
 	})
 
@@ -37,12 +36,12 @@ func TestFairBalancer(t *testing.T) {
 	// Start the first and let it claim a bunch of tasks
 	go con1.Run()
 	defer con1.Shutdown()
-	cli.SubmitTask("t1")
-	cli.SubmitTask("t2")
-	cli.SubmitTask("t3")
-	cli.SubmitTask("t4")
-	cli.SubmitTask("t5")
-	cli.SubmitTask("t6")
+	cli.SubmitTask(DefaultTaskFunc("t1", ""))
+	cli.SubmitTask(DefaultTaskFunc("t2", ""))
+	cli.SubmitTask(DefaultTaskFunc("t3", ""))
+	cli.SubmitTask(DefaultTaskFunc("t4", ""))
+	cli.SubmitTask(DefaultTaskFunc("t5", ""))
+	cli.SubmitTask(DefaultTaskFunc("t6", ""))
 
 	time.Sleep(500 * time.Millisecond)
 
@@ -93,16 +92,15 @@ func TestFairBalancer(t *testing.T) {
 // See https://github.com/lytics/metafora/issues/92
 func TestFairBalancerShutdown(t *testing.T) {
 	coord1, etcdc := setupEtcd(t)
-	c2, _ := NewEtcdCoordinator("node2", namespace, etcdc)
-	coord2 := c2.(*EtcdCoordinator)
+	coord2, _ := NewEtcdCoordinator("node2", namespace, etcdc)
 
 	cli := NewClient(namespace, etcdc)
 
 	// This handler always returns immediately
-	h1 := metafora.SimpleHandler(func(task string, stop <-chan bool) bool {
-		metafora.Debugf("H1 Starting %s", task)
+	h1 := metafora.SimpleHandler(func(task metafora.Task, stop <-chan bool) bool {
+		metafora.Debugf("H1 Starting %s", task.ID())
 		<-stop
-		metafora.Debugf("H1 Stopping %s", task)
+		metafora.Debugf("H1 Stopping %s", task.ID())
 		return false // never done
 	})
 
@@ -110,14 +108,14 @@ func TestFairBalancerShutdown(t *testing.T) {
 	stop2 := make(chan struct{})
 	stopr := make(chan chan struct{}, 1)
 	stopr <- stop2
-	h2 := metafora.SimpleHandler(func(task string, stop <-chan bool) bool {
-		metafora.Debugf("H2 Starting %s", task)
+	h2 := metafora.SimpleHandler(func(task metafora.Task, stop <-chan bool) bool {
+		metafora.Debugf("H2 Starting %s", task.ID())
 		blockchan, ok := <-stopr
 		if ok {
 			<-blockchan
 		}
 		<-stop
-		metafora.Debugf("H2 Stopping %s", task)
+		metafora.Debugf("H2 Stopping %s", task.ID())
 		return false // never done
 	})
 
@@ -137,12 +135,12 @@ func TestFairBalancerShutdown(t *testing.T) {
 	// Start the first and let it claim a bunch of tasks
 	go con1.Run()
 	defer con1.Shutdown()
-	cli.SubmitTask("t1")
-	cli.SubmitTask("t2")
-	cli.SubmitTask("t3")
-	cli.SubmitTask("t4")
-	cli.SubmitTask("t5")
-	cli.SubmitTask("t6")
+	cli.SubmitTask(DefaultTaskFunc("t1", ""))
+	cli.SubmitTask(DefaultTaskFunc("t2", ""))
+	cli.SubmitTask(DefaultTaskFunc("t3", ""))
+	cli.SubmitTask(DefaultTaskFunc("t4", ""))
+	cli.SubmitTask(DefaultTaskFunc("t5", ""))
+	cli.SubmitTask(DefaultTaskFunc("t6", ""))
 
 	time.Sleep(500 * time.Millisecond)
 

--- a/m_etcd/client_test.go
+++ b/m_etcd/client_test.go
@@ -55,15 +55,17 @@ func TestSubmitTask(t *testing.T) {
 
 	mclient := NewClient(Namespace, hosts)
 
-	if err := mclient.DeleteTask("testid1"); err != nil {
+	task := DefaultTaskFunc("testid1", "")
+
+	if err := mclient.DeleteTask(task.ID()); err != nil {
 		t.Logf("DeleteTask returned an error, which maybe ok.  Error:%v", err)
 	}
 
-	if err := mclient.SubmitTask("testid1"); err != nil {
+	if err := mclient.SubmitTask(task); err != nil {
 		t.Fatalf("Submit task failed on initial submission, error: %v", err)
 	}
 
-	if err := mclient.SubmitTask("testid1"); err == nil {
+	if err := mclient.SubmitTask(task); err == nil {
 		t.Fatalf("Submit task did not fail, but should of, when using existing tast id")
 	}
 }

--- a/m_etcd/commander.go
+++ b/m_etcd/commander.go
@@ -54,12 +54,12 @@ type cmdrListener struct {
 // NewCommandListener makes a statemachine.CommandListener implementation
 // backed by etcd. The namespace should be the same as the coordinator as
 // commands use a separate path within a namespace than tasks or nodes.
-func NewCommandListener(taskID, namespace string, c *etcd.Client) statemachine.CommandListener {
+func NewCommandListener(task metafora.Task, namespace string, c *etcd.Client) statemachine.CommandListener {
 	if namespace[0] != '/' {
 		namespace = "/" + namespace
 	}
 	cl := &cmdrListener{
-		path:     path.Join(namespace, commandPath, taskID),
+		path:     path.Join(namespace, commandPath, task.ID()),
 		cli:      c,
 		commands: make(chan statemachine.Message),
 		mu:       &sync.Mutex{},

--- a/m_etcd/const.go
+++ b/m_etcd/const.go
@@ -6,6 +6,7 @@ const (
 	CommandsPath = "commands"
 	MetadataKey  = "_metafora" // _{KEYs} are hidden files, so this will not trigger our watches
 	OwnerMarker  = "owner"
+	PropsKey     = "props"
 
 	ForeverTTL = 0 //Ref: https://github.com/coreos/go-etcd/blob/e10c58ee110f54c2f385ac99764e8a7ca4cb13df/etcd/requests.go#L356
 

--- a/m_etcd/coordinator_test.go
+++ b/m_etcd/coordinator_test.go
@@ -47,9 +47,9 @@ func TestCoordinatorTC1(t *testing.T) {
 	defer coordinator1.Close()
 	client, _ := testutil.NewEtcdClient(t)
 
-	tasks := make(chan string)
-	task001 := "test-task"
-	taskPath := path.Join(namespace, TasksPath, task001)
+	tasks := make(chan metafora.Task)
+	task001 := &task{id: "test-task"}
+	taskPath := path.Join(namespace, TasksPath, task001.ID())
 	errc := make(chan error)
 
 	go func() {
@@ -60,9 +60,9 @@ func TestCoordinatorTC1(t *testing.T) {
 	client.CreateDir(taskPath, 5)
 
 	select {
-	case taskId := <-tasks:
-		if taskId != task001 {
-			t.Fatalf("coordinator1.Watch() test failed: We received the incorrect taskId.  Got [%s] Expected[%s]", taskId, task001)
+	case task := <-tasks:
+		if task.ID() != task001.ID() {
+			t.Fatalf("coordinator1.Watch() test failed: We received the incorrect taskId.  Got [%s] Expected[%s]", task, task001)
 		}
 	case <-time.After(time.Second * 5):
 		t.Fatalf("coordinator1.Watch() test failed: The testcase timed out after 5 seconds.")
@@ -87,23 +87,23 @@ func TestCoordinatorTC2(t *testing.T) {
 
 	mclient := NewClient(namespace, client)
 
-	tasks := make(chan string)
+	tasks := make(chan metafora.Task)
 	errc := make(chan error)
 	go func() {
 		//Watch blocks, so we need to test it in its own go routine.
 		errc <- coordinator1.Watch(tasks)
 	}()
 
-	for _, task := range testTasks {
-		err := mclient.SubmitTask(task)
+	for _, taskid := range testTasks {
+		err := mclient.SubmitTask(DefaultTaskFunc(taskid, ""))
 		if err != nil {
 			t.Fatalf("Error submitting a task to metafora via the client.  Error:\n%v", err)
 		}
 		recvd := <-tasks
-		if recvd != task {
-			t.Fatalf("%s != %s - received an unexpected task", recvd, task)
+		if recvd.ID() != taskid {
+			t.Fatalf("%s != %s - received an unexpected task", recvd.ID(), taskid)
 		}
-		if ok := coordinator1.Claim(task); !ok {
+		if ok := coordinator1.Claim(recvd); !ok {
 			t.Fatal("coordinator1.Claim() unable to claim the task")
 		}
 	}
@@ -123,8 +123,7 @@ func TestCoordinatorTC3(t *testing.T) {
 		t.Fatalf("Unexpected error initialzing coordinator: %v", err)
 	}
 	defer coordinator1.Close()
-	c2, _ := NewEtcdCoordinator("node2", namespace, hosts)
-	coordinator2 := c2.(*EtcdCoordinator)
+	coordinator2, _ := NewEtcdCoordinator("node2", namespace, hosts)
 	if err := coordinator2.Init(newCtx(t, "coordinator2")); err != nil {
 		t.Fatalf("Unexpected error initialzing coordinator: %v", err)
 	}
@@ -136,8 +135,8 @@ func TestCoordinatorTC3(t *testing.T) {
 
 	// Start the watchers
 	errc := make(chan error, 2)
-	c1tasks := make(chan string)
-	c2tasks := make(chan string)
+	c1tasks := make(chan metafora.Task)
+	c2tasks := make(chan metafora.Task)
 	go func() {
 		errc <- coordinator1.Watch(c1tasks)
 	}()
@@ -147,7 +146,7 @@ func TestCoordinatorTC3(t *testing.T) {
 
 	// Submit the tasks
 	for _, tid := range testTasks {
-		err := mclient.SubmitTask(tid)
+		err := mclient.SubmitTask(DefaultTaskFunc(tid, ""))
 		if err != nil {
 			t.Fatalf("Error submitting task=%q to metafora via the client. Error:\n%v", tid, err)
 		}
@@ -157,18 +156,18 @@ func TestCoordinatorTC3(t *testing.T) {
 	//    submitted to etcd which, while /possible/ to guarantee, isn't a gurantee
 	//    we're interested in making. Remove this section if it starts causing problems.
 	//    We only want to guarantee that exactly one coordinator can claim a task.
-	c1tid := <-c1tasks
-	c2tid := <-c2tasks
-	if c1tid != c2tid {
-		t.Fatalf("Watchers didn't receive the same task %s != %s. Might be fine; see code.", c1tid, c2tid)
+	c1t := <-c1tasks
+	c2t := <-c2tasks
+	if c1t.ID() != c2t.ID() {
+		t.Fatalf("Watchers didn't receive the same task %s != %s. Might be fine; see code.", c1t, c2t)
 	}
 
 	// Make sure c1 can claim and c2 cannot
-	if ok := coordinator1.Claim(c1tid); !ok {
-		t.Fatalf("coordinator1.Claim() unable to claim the task=%q", c1tid)
+	if ok := coordinator1.Claim(c1t); !ok {
+		t.Fatalf("coordinator1.Claim() unable to claim the task=%q", c1t)
 	}
-	if ok := coordinator2.Claim(c1tid); ok {
-		t.Fatalf("coordinator2.Claim() succeeded for task=%q when it shouldn't have!", c2tid)
+	if ok := coordinator2.Claim(c1t); ok {
+		t.Fatalf("coordinator2.Claim() succeeded for task=%q when it shouldn't have!", c2t)
 	}
 
 	// Make sure coordinators close down properly and quickly
@@ -194,7 +193,7 @@ func TestCoordinatorTC4(t *testing.T) {
 
 	mclient := NewClient(namespace, hosts)
 
-	err := mclient.SubmitTask(task)
+	err := mclient.SubmitTask(DefaultTaskFunc(task, ""))
 	if err != nil {
 		t.Fatalf("Error submitting a task to metafora via the client. Error:\n%v", err)
 	}
@@ -206,7 +205,7 @@ func TestCoordinatorTC4(t *testing.T) {
 	defer coordinator1.Close()
 
 	errc := make(chan error)
-	c1tasks := make(chan string)
+	c1tasks := make(chan metafora.Task)
 	go func() {
 		errc <- coordinator1.Watch(c1tasks)
 	}()
@@ -218,14 +217,13 @@ func TestCoordinatorTC4(t *testing.T) {
 	}
 
 	// Startup a second
-	c2, _ := NewEtcdCoordinator("node2", namespace, hosts)
-	coordinator2 := c2.(*EtcdCoordinator)
+	coordinator2, _ := NewEtcdCoordinator("node2", namespace, hosts)
 	if err := coordinator2.Init(newCtx(t, "coordinator2")); err != nil {
 		t.Fatalf("Unexpected error initialzing coordinator: %v", err)
 	}
 	defer coordinator2.Close()
 
-	c2tasks := make(chan string)
+	c2tasks := make(chan metafora.Task)
 	go func() {
 		errc <- coordinator2.Watch(c2tasks)
 	}()
@@ -386,7 +384,7 @@ func TestNodeRefresher(t *testing.T) {
 func TestExpiration(t *testing.T) {
 	metafora.SetLogLevel(metafora.LogLevelDebug)
 	coord, _ := setupEtcd(t)
-	hf := metafora.HandlerFunc(metafora.SimpleHandler(func(taskID string, stop <-chan bool) bool {
+	hf := metafora.HandlerFunc(metafora.SimpleHandler(func(_ metafora.Task, stop <-chan bool) bool {
 		<-stop
 		return true
 	}))

--- a/m_etcd/helpers_test.go
+++ b/m_etcd/helpers_test.go
@@ -26,7 +26,7 @@ func setupEtcd(t *testing.T) (*EtcdCoordinator, []string) {
 	if err != nil {
 		t.Fatalf("Error creating etcd coordinator: %v", err)
 	}
-	return coord.(*EtcdCoordinator), hosts
+	return coord, hosts
 }
 
 type testLogger struct {
@@ -50,7 +50,7 @@ func newCtx(t *testing.T, prefix string) *testCoordCtx {
 	}
 }
 
-func (t *testCoordCtx) Lost(taskID string) {
-	t.Log(metafora.LogLevelDebug, "Lost(%s)", taskID)
-	t.lost <- taskID
+func (t *testCoordCtx) Lost(task metafora.Task) {
+	t.Log(metafora.LogLevelDebug, "Lost(%s)", task.ID())
+	t.lost <- task.ID()
 }

--- a/m_etcd/parse_test.go
+++ b/m_etcd/parse_test.go
@@ -1,62 +1,117 @@
 package m_etcd
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/lytics/metafora"
+	"github.com/lytics/metafora/m_etcd/testutil"
 )
 
 type ctx struct{}
 
-func (ctx) Lost(string)                                   {}
+func (ctx) Lost(metafora.Task)                            {}
 func (ctx) Log(metafora.LogLevel, string, ...interface{}) {}
 
 type taskTest struct {
 	Resp *etcd.Response
-	Task string
+	Task mapTask
 	Ok   bool
 }
 
+type mapTask map[string]interface{}
+
+func (m mapTask) ID() string { return m["id"].(string) }
+
 func TestParseTask(t *testing.T) {
-	c := EtcdCoordinator{taskPath: "/namespace/tasks", cordCtx: &ctx{}}
+	etcdc, _ := testutil.NewEtcdClient(t)
+	t.Parallel()
+
+	etcdc.Delete("test-parse", recursive)
+
+	c := EtcdCoordinator{taskPath: "/test-parse/tasks", cordCtx: &ctx{}, NewTask: DefaultTaskFunc, client: etcdc}
+	c.NewTask = func(id, value string) metafora.Task {
+		tsk := mapTask{"id": id}
+		if value == "" {
+			return tsk
+		}
+		if err := json.Unmarshal([]byte(value), &tsk); err != nil {
+			metafora.Warnf("Failed to unmarshal %q: %v", value, err)
+			return nil
+		}
+		return tsk
+	}
+
+	// Unfortunately parseTasks sometimes has to go back out to etcd for
+	// properties. Insert test data.
+	etcdc.Create("/test-parse/tasks/0/props", "{invalid", ForeverTTL)
 
 	tests := []taskTest{
 		// bad
-		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/1", Dir: true}}},
-		{Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{Key: "/namespace/tasks/1/a", Dir: true}}},
-		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/1", Dir: false}}},
+		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/test-parse/tasks/0/owner", Dir: false}}},
+		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/test-parse/oops/1", Dir: true}}},
+		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/test-parse/tasks/1", Dir: true}}},
+		{Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{Key: "/test-parse/tasks/1/a", Dir: true}}},
+		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/test-parse/tasks/1", Dir: false}}},
 
 		// good
 		{
-			Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{Key: "/namespace/tasks/1", Dir: true}},
-			Task: "1",
+			Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{Key: "/test-parse/tasks/1", Dir: true}},
+			Task: mapTask{"id": "1"},
 			Ok:   true,
 		},
 		{
-			Resp: &etcd.Response{Action: actionSet, Node: &etcd.Node{Key: "/namespace/tasks/1", Dir: true}},
-			Task: "1",
+			Resp: &etcd.Response{Action: actionSet, Node: &etcd.Node{Key: "/test-parse/tasks/2", Dir: true}},
+			Task: mapTask{"id": "2"},
 			Ok:   true,
 		},
 		{
-			Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/1/owner"}},
-			Task: "1",
+			Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/test-parse/tasks/3/owner"}},
+			Task: mapTask{"id": "3"},
 			Ok:   true,
 		},
 		{
-			Resp: &etcd.Response{Action: actionDelete, Node: &etcd.Node{Key: "/namespace/tasks/1/owner"}},
-			Task: "1",
+			Resp: &etcd.Response{Action: actionDelete, Node: &etcd.Node{Key: "/test-parse/tasks/4/owner"}},
+			Task: mapTask{"id": "4"},
+			Ok:   true,
+		},
+		{
+			Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{
+				Key:   "/test-parse/tasks/5",
+				Nodes: []*etcd.Node{{Key: "/test-parse/tasks/5/props", Value: `{"test": "ok"}`}},
+				Dir:   true,
+			}},
+			Task: mapTask{"id": "5", "test": "ok"},
+			Ok:   true,
+		},
+		{
+			Resp: &etcd.Response{Action: actionSet, Node: &etcd.Node{Key: "/test-parse/tasks/6/props", Value: `{"test":"ok"}`}},
+			Task: mapTask{"id": "6", "test": "ok"},
 			Ok:   true,
 		},
 	}
 
 	for _, test := range tests {
-		task, ok := c.parseTask(test.Resp)
-		if task != test.Task {
-			t.Errorf("Test %s:%v failed: %s != %s", test.Resp.Action, *test.Resp.Node, task, test.Task)
+		parsed := c.parseTask(test.Resp)
+		if parsed == nil {
+			if test.Ok {
+				t.Errorf("Test %s:%v failed: expected task: %s", test.Resp.Action, *test.Resp.Node, test.Task)
+			}
+			continue
 		}
-		if ok != test.Ok {
-			t.Errorf("Test %s:%v failed: %v != %v", test.Resp.Action, *test.Resp.Node, ok, test.Ok)
+		if !test.Ok {
+			t.Errorf("Test %s:%v should have failed, but did not!", test.Resp.Action, *test.Resp.Node)
+			continue
+		}
+		mt, ok := parsed.(mapTask)
+		if !ok {
+			t.Errorf("Test %s:%v didn't return a mapTask: %T", test.Resp.Action, *test.Resp.Node, parsed)
+		}
+		for k, v := range test.Task {
+			if mt[k] != v {
+				t.Errorf("Test %s:%v failed: %#v != %#v", test.Resp.Action, *test.Resp.Node, mt, test.Task)
+			}
 		}
 	}
 }

--- a/m_etcd/task.go
+++ b/m_etcd/task.go
@@ -1,0 +1,21 @@
+package m_etcd
+
+import "github.com/lytics/metafora"
+
+type task struct {
+	id string
+}
+
+func (t *task) ID() string { return t.id }
+
+// TaskFunc creates a Task interface from a task ID and etcd Node. The Node
+// corresponds to the task directory.
+//
+// Implementations must support value being an empty string.
+//
+// If nil is returned the task is ignored.
+type TaskFunc func(id, value string) metafora.Task
+
+// DefaultTaskFunc is the default new task function used by the EtcdCoordinator
+// and does not attempt to process the properties value.
+func DefaultTaskFunc(id, _ string) metafora.Task { return &task{id: id} }

--- a/m_etcd/task_test.go
+++ b/m_etcd/task_test.go
@@ -1,0 +1,87 @@
+package m_etcd_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lytics/metafora"
+	"github.com/lytics/metafora/m_etcd"
+	"github.com/lytics/metafora/m_etcd/testutil"
+	"github.com/lytics/metafora/statemachine"
+)
+
+// exTask is an extended Task type to demonstrate using an alternative NewTask
+// TaskFunc.
+type exTask struct {
+	id         string
+	SubmittedT *time.Time `json:"_submitted"`
+	UserID     string     `json:userid`
+}
+
+func (t *exTask) ID() string            { return t.id }
+func (t *exTask) Submitted() *time.Time { return t.SubmittedT }
+func (t *exTask) String() string {
+	if t.SubmittedT == nil {
+		return t.id
+	}
+	return fmt.Sprintf("%s submitted %s", t.id, t.SubmittedT)
+}
+
+func TestAltTask(t *testing.T) {
+	etcdc, hosts := testutil.NewEtcdClient(t)
+	metafora.SetLogLevel(metafora.LogLevelDebug)
+	t.Parallel()
+	const namespace = "alttask-metafora"
+
+	etcdc.Delete(namespace, recursive)
+
+	// Create a handler that returns results through a chan for synchronization
+	results := make(chan string, 1)
+
+	h := func(task metafora.Task, _ <-chan statemachine.Message) statemachine.Message {
+		alttask, ok := task.(*exTask)
+		if !ok {
+			results <- fmt.Sprintf("%q is of type %T", task.ID(), task)
+			return statemachine.Message{Code: statemachine.Pause}
+		}
+		if alttask.UserID == "" {
+			results <- "missing UserID"
+			return statemachine.Message{Code: statemachine.Pause}
+		}
+		results <- "ok"
+		return statemachine.Message{Code: statemachine.Pause}
+	}
+
+	coord, hf, bal, err := m_etcd.New("node1", namespace, hosts, h)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sample overridden NewTask func
+	coord.(*m_etcd.EtcdCoordinator).NewTask = func(id, props string) metafora.Task {
+		task := exTask{id: id}
+		if err := json.Unmarshal([]byte(props), &task); err != nil {
+			metafora.Warnf("%s properties could not be unmarshalled: %v", id, err)
+		}
+		return &task
+	}
+
+	consumer, err := metafora.NewConsumer(coord, hf, bal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go consumer.Run()
+	defer consumer.Shutdown()
+
+	cli := m_etcd.NewClient(namespace, hosts)
+	if err := cli.SubmitTask(&exTask{id: "test1", UserID: "test2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := <-results
+	if result != "ok" {
+		t.Fatal(result)
+	}
+}

--- a/m_etcd/taskmgr.go
+++ b/m_etcd/taskmgr.go
@@ -80,9 +80,10 @@ func (m *taskManager) ownerNode(taskID string) (key, value string) {
 }
 
 // add starts refreshing a given key+value pair for a task asynchronously.
-func (m *taskManager) add(taskID string) bool {
+func (m *taskManager) add(task metafora.Task) bool {
+	tid := task.ID()
 	// Attempt to claim the node
-	key, value := m.ownerNode(taskID)
+	key, value := m.ownerNode(tid)
 	resp, err := m.client.Create(key, value, m.ttl)
 	if err != nil {
 		etcdErr, ok := err.(*etcd.EtcdError)
@@ -100,22 +101,22 @@ func (m *taskManager) add(taskID string) bool {
 	// deleted (done) task. Compare the CreatedIndex of the directory with the
 	// CreatedIndex of the claim key, if they're equal this claim ressurected a
 	// done task and should cleanup.
-	resp, err = m.client.Get(m.taskPath(taskID), unsorted, notrecursive)
+	resp, err = m.client.Get(m.taskPath(tid), unsorted, notrecursive)
 	if err != nil {
 		// Erroring here is BAD as we may have resurrected a done task, and because
 		// of this failure there's no way to tell. The claim will eventually
 		// timeout and the task will get reclaimed.
-		metafora.Errorf("Error retrieving task path %q after claiming %q: %v", m.taskPath(taskID), taskID, err)
+		metafora.Errorf("Error retrieving task path %q after claiming %q: %v", m.taskPath(tid), tid, err)
 		return false
 	}
 
 	if resp.Node.CreatedIndex == index {
-		metafora.Debugf("Task %s resurrected due to claim/done race. Re-deleting.", taskID)
-		if _, err = m.client.Delete(m.taskPath(taskID), recursive); err != nil {
+		metafora.Debugf("Task %s resurrected due to claim/done race. Re-deleting.", tid)
+		if _, err = m.client.Delete(m.taskPath(tid), recursive); err != nil {
 			// This is as bad as it gets. We *know* we resurrected a task, but we
 			// failed to re-delete it.
 			metafora.Errorf("Task %s was resurrected and could not be removed! %s should be manually removed. Error: %v",
-				taskID, m.taskPath(taskID), err)
+				tid, m.taskPath(tid), err)
 		}
 
 		// Regardless of whether or not the delete succeeded, never treat
@@ -129,14 +130,14 @@ func (m *taskManager) add(taskID string) bool {
 	release := make(chan struct{})
 	finished := make(chan struct{})
 	m.taskL.Lock()
-	m.tasks[taskID] = taskStates{done: done, release: release, finished: finished}
+	m.tasks[tid] = taskStates{done: done, release: release, finished: finished}
 	m.taskL.Unlock()
 
-	metafora.Debugf("Starting claim refresher for task %s", taskID)
+	metafora.Debugf("Starting claim refresher for task %s", tid)
 	go func() {
 		defer func() {
 			m.taskL.Lock()
-			delete(m.tasks, taskID)
+			delete(m.tasks, tid)
 			m.taskL.Unlock()
 			close(finished)
 		}()
@@ -146,23 +147,23 @@ func (m *taskManager) add(taskID string) bool {
 			case <-time.After(m.interval):
 				// Try to refresh the claim node (0 index means compare by value)
 				if _, err := m.client.CompareAndSwap(key, value, m.ttl, value, 0); err != nil {
-					metafora.Errorf("Error trying to update task %s ttl: %v", taskID, err)
-					m.ctx.Lost(taskID)
+					metafora.Errorf("Error trying to update task %s ttl: %v", tid, err)
+					m.ctx.Lost(task)
 					// On errors, don't even try to Delete as we're in a bad state
 					return
 				}
 			case <-done:
-				metafora.Debugf("Deleting directory for task %s as it's done.", taskID)
+				metafora.Debugf("Deleting directory for task %s as it's done.", tid)
 				const recursive = true
-				if _, err := m.client.Delete(m.taskPath(taskID), recursive); err != nil {
-					metafora.Errorf("Error deleting task %s while stopping: %v", taskID, err)
+				if _, err := m.client.Delete(m.taskPath(tid), recursive); err != nil {
+					metafora.Errorf("Error deleting task %s while stopping: %v", tid, err)
 				}
 				return
 			case <-release:
-				metafora.Debugf("Deleting claim for task %s as it's released.", taskID)
+				metafora.Debugf("Deleting claim for task %s as it's released.", tid)
 				// Not done, releasing; just delete the claim node
 				if _, err := m.client.CompareAndDelete(key, value, 0); err != nil {
-					metafora.Warnf("Error releasing task %s while stopping: %v", taskID, err)
+					metafora.Warnf("Error releasing task %s while stopping: %v", tid, err)
 				}
 				return
 			}

--- a/m_etcd/taskmgr_test.go
+++ b/m_etcd/taskmgr_test.go
@@ -74,7 +74,7 @@ func TestTaskResurrection(t *testing.T) {
 	client := newFakeEtcd()
 	const ttl = 2
 	mgr := newManager(newCtx(t, "mgr"), client, "testns", "testnode", ttl)
-	if added := mgr.add("zombie"); added {
+	if added := mgr.add(&task{id: "zombie"}); added {
 		t.Fatal("Added zombie task when it should have been deleted.")
 	}
 }
@@ -89,7 +89,7 @@ func TestTaskRefreshing(t *testing.T) {
 	client := newFakeEtcd()
 	const ttl = 2
 	mgr := newManager(newCtx(t, "mgr"), client, "testns", "testnode", ttl)
-	if added := mgr.add("tid"); !added {
+	if added := mgr.add(&task{id: "tid"}); !added {
 		t.Fatal("Failed to add task!")
 	}
 	for i := 0; i < 2; i++ {
@@ -114,7 +114,7 @@ func TestTaskRemoval(t *testing.T) {
 	client := newFakeEtcd()
 	const ttl = 2
 	mgr := newManager(newCtx(t, "mgr"), client, "testns", "testnode", ttl)
-	mgr.add("tid")
+	mgr.add(&task{id: "tid"})
 	mgr.remove("tid", false)
 	select {
 	case <-client.add:
@@ -147,9 +147,9 @@ func TestFullTaskMgr(t *testing.T) {
 	mgr := newManager(newCtx(t, "mgr"), client, "testns", "testnode", ttl)
 
 	// Add a few tasks and remove one
-	mgr.add("tid1")
-	mgr.add("tid2")
-	mgr.add("tid3")
+	mgr.add(&task{id: "tid1"})
+	mgr.add(&task{id: "tid2"})
+	mgr.add(&task{id: "tid3"})
 	mgr.remove("tid2", false)
 
 	delDone := false
@@ -208,7 +208,7 @@ func TestTaskLost(t *testing.T) {
 	const ttl = 2
 	mgr := newManager(ctx, client, "testns", "testnode", ttl)
 
-	mgr.add("testlost")
+	mgr.add(&task{id: "testlost"})
 
 	// Wait for the CAS to fail
 	time.Sleep(ttl * time.Second)
@@ -243,8 +243,8 @@ func TestTaskDone(t *testing.T) {
 	const ttl = 2
 	mgr := newManager(ctx, client, "testns", "testnode", ttl)
 
-	mgr.add("t1")
-	mgr.add("t2")
+	mgr.add(&task{id: "t1"})
+	mgr.add(&task{id: "t2"})
 	mgr.remove("t1", true)
 	mgr.remove("t2", false)
 

--- a/statemachine/errors.go
+++ b/statemachine/errors.go
@@ -3,6 +3,8 @@ package statemachine
 import (
 	"errors"
 	"time"
+
+	"github.com/lytics/metafora"
 )
 
 // ExceededErrorRate is returned by error handlers in an Error Message when
@@ -21,7 +23,7 @@ type Err struct {
 //
 // Either ErrHandler and/or StateStore should trim the error slice to keep it
 // from growing without bound.
-type ErrHandler func(taskID string, errs []Err) (Message, []Err)
+type ErrHandler func(task metafora.Task, errs []Err) (Message, []Err)
 
 const (
 	DefaultErrLifetime = -4 * time.Hour
@@ -31,7 +33,7 @@ const (
 // DefaultErrHandler returns a Fail message if 8 errors have occurred in 4
 // hours. Otherwise it enters the Sleep state for 10 minutes before trying
 // again.
-func DefaultErrHandler(_ string, errs []Err) (Message, []Err) {
+func DefaultErrHandler(_ metafora.Task, errs []Err) (Message, []Err) {
 	recent := time.Now().Add(DefaultErrLifetime)
 	strikes := 0
 	for _, err := range errs {

--- a/statemachine/errors_test.go
+++ b/statemachine/errors_test.go
@@ -7,6 +7,10 @@ import (
 	. "github.com/lytics/metafora/statemachine"
 )
 
+type task string
+
+func (t task) ID() string { return string(t) }
+
 func TestDefaultErrHandler(t *testing.T) {
 	t.Parallel()
 	tid := ""
@@ -14,7 +18,7 @@ func TestDefaultErrHandler(t *testing.T) {
 	errs := []Err{{Time: time.Now()}}
 
 	{
-		msg, errs := DefaultErrHandler(tid, errs)
+		msg, errs := DefaultErrHandler(task(tid), errs)
 		if len(errs) != 1 {
 			t.Fatalf("Expected 1 err, found: %d", len(errs))
 		}
@@ -29,7 +33,7 @@ func TestDefaultErrHandler(t *testing.T) {
 	}
 
 	{
-		msg, errs := DefaultErrHandler(tid, errs)
+		msg, errs := DefaultErrHandler(task(tid), errs)
 		if len(errs) > DefaultErrMax {
 			t.Fatalf("Expected %d errors but received: %d", DefaultErrMax, len(errs))
 		}

--- a/statemachine/run_test.go
+++ b/statemachine/run_test.go
@@ -3,7 +3,13 @@ package statemachine
 import (
 	"testing"
 	"time"
+
+	"github.com/lytics/metafora"
 )
+
+type task string
+
+func (t task) ID() string { return string(t) }
 
 // TestCommandBlackhole is meant to demonstrate what happens if a
 // StatefulHandler implementation receives commands in a goroutine that lives
@@ -21,7 +27,7 @@ func TestCommandBlackhole(t *testing.T) {
 	rdy := make(chan int, 1)
 	defer close(stop)
 
-	f := func(_ string, c <-chan Message) Message {
+	f := func(_ metafora.Task, c <-chan Message) Message {
 		go func() {
 			rdy <- 1
 			select {
@@ -37,7 +43,7 @@ func TestCommandBlackhole(t *testing.T) {
 
 	// Ignore the return message, the point is to make sure it doesn't intercept
 	// further commands.
-	run(f, "test-task", cmds)
+	run(f, task("test-task"), cmds)
 
 	go func() { cmds <- Message{Code: Run} }()
 

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -196,10 +196,10 @@ var (
 // a different Message. For example if it encounters an error during shutdown,
 // it may choose to return that error as an Error Message as opposed to the
 // original command.
-type StatefulHandler func(taskID string, commands <-chan Message) Message
+type StatefulHandler func(task metafora.Task, commands <-chan Message) Message
 
 type stateMachine struct {
-	taskID     string
+	task       metafora.Task
 	h          StatefulHandler
 	ss         StateStore
 	cl         CommandListener
@@ -219,12 +219,12 @@ type stateMachine struct {
 // the HandlerFunc you use with metafora's Consumer.
 //
 // If ErrHandler is nil DefaultErrHandler will be used.
-func New(tid string, h StatefulHandler, ss StateStore, cl CommandListener, e ErrHandler) metafora.Handler {
+func New(task metafora.Task, h StatefulHandler, ss StateStore, cl CommandListener, e ErrHandler) metafora.Handler {
 	if e == nil {
 		e = DefaultErrHandler
 	}
 	return &stateMachine{
-		taskID:     tid,
+		task:       task,
 		h:          h,
 		ss:         ss,
 		cl:         cl,
@@ -282,16 +282,18 @@ func (s *stateMachine) Run() (done bool) {
 		s.stop()
 	}()
 
+	tid := s.task.ID()
+
 	// Load the initial state
-	state, err := s.ss.Load(s.taskID)
+	state, err := s.ss.Load(s.task)
 	if err != nil {
 		// A failure to load the state for a task is *fatal* - the task will be
 		// unscheduled and requires operator intervention to reschedule.
-		metafora.Errorf("task=%q could not load initial state. Marking done! Error: %v", s.taskID, err)
+		metafora.Errorf("task=%q could not load initial state. Marking done! Error: %v", tid, err)
 		return true
 	}
 	if state.Code.Terminal() {
-		metafora.Warnf("task=%q in terminal state %s - exiting.", s.taskID, state.Code)
+		metafora.Warnf("task=%q in terminal state %s - exiting.", tid, state.Code)
 		return true
 	}
 	s.setState(state)
@@ -300,25 +302,25 @@ func (s *stateMachine) Run() (done bool) {
 	done = false
 	for {
 		// Enter State
-		metafora.Debugf("task=%q in state %s", s.taskID, state.Code)
+		metafora.Debugf("task=%q in state %s", tid, state.Code)
 		msg := s.exec(state)
 
 		// Apply Message
 		newstate, ok := apply(state, msg)
 		if !ok {
-			metafora.Warnf("task=%q Invalid state transition=%q returned by task. Old state=%q", s.taskID, msg.Code, state.Code)
+			metafora.Warnf("task=%q Invalid state transition=%q returned by task. Old state=%q", tid, msg.Code, state.Code)
 			msg = Message{Code: Error, Err: err}
 			if newstate, ok = apply(state, msg); !ok {
-				metafora.Errorf("task=%q Unable to transition to error state! Exiting with state=%q", s.taskID, state.Code)
+				metafora.Errorf("task=%q Unable to transition to error state! Exiting with state=%q", tid, state.Code)
 				return state.Code.Terminal()
 			}
 		}
 
-		metafora.Infof("task=%q transitioning %s --> %s --> %s", s.taskID, state, msg, newstate)
+		metafora.Infof("task=%q transitioning %s --> %s --> %s", tid, state, msg, newstate)
 
 		// Save state
-		if err := s.ss.Store(s.taskID, newstate); err != nil {
-			metafora.Errorf("task=%q Unable to persist state=%q. Unscheduling.", s.taskID, newstate.Code)
+		if err := s.ss.Store(s.task, newstate); err != nil {
+			metafora.Errorf("task=%q Unable to persist state=%q. Unscheduling.", tid, newstate.Code)
 			return true
 		}
 
@@ -354,18 +356,18 @@ func (s *stateMachine) exec(state *State) Message {
 	switch state.Code {
 	case Runnable:
 		// Runnable passes control to the stateful handler
-		return run(s.h, s.taskID, s.cmds)
+		return run(s.h, s.task, s.cmds)
 	case Paused:
 		// Paused until a message arrives
 		return <-s.cmds
 	case Sleeping:
 		// Sleeping until the specified time (or a message)
 		if state.Until == nil {
-			metafora.Warnf("task=%q told to sleep without a time. Resuming.", s.taskID)
+			metafora.Warnf("task=%q told to sleep without a time. Resuming.", s.task.ID())
 			return Message{Code: Run}
 		}
 		dur := state.Until.Sub(time.Now())
-		metafora.Infof("task=%q sleeping for %s", s.taskID, dur)
+		metafora.Infof("task=%q sleeping for %s", s.task.ID(), dur)
 		timer := time.NewTimer(dur)
 		select {
 		case <-timer.C:
@@ -383,17 +385,17 @@ func (s *stateMachine) exec(state *State) Message {
 		// Special case where we potentially trim the current state to keep
 		// errors from growing without bound.
 		var msg Message
-		msg, state.Errors = s.errHandler(s.taskID, state.Errors)
+		msg, state.Errors = s.errHandler(s.task, state.Errors)
 		return msg
 	default:
 		panic("invalid state: " + state.String())
 	}
 }
 
-func run(f StatefulHandler, tid string, cmd <-chan Message) (m Message) {
+func run(f StatefulHandler, task metafora.Task, cmd <-chan Message) (m Message) {
 	defer func() {
 		if r := recover(); r != nil {
-			metafora.Errorf("task=%q Run method panic()d! Applying Error message. Panic: %v", tid, r)
+			metafora.Errorf("task=%q Run method panic()d! Applying Error message. Panic: %v", task.ID(), r)
 			m = Message{Code: Error, Err: fmt.Errorf("panic: %v", r)}
 		}
 	}()
@@ -416,16 +418,19 @@ func run(f StatefulHandler, tid string, cmd <-chan Message) (m Message) {
 	}()
 	defer close(stopped)
 
-	return f(tid, internalcmd)
+	return f(task, internalcmd)
 }
 
 // Stop sends a Release message to the state machine through the command chan.
 func (s *stateMachine) Stop() {
-	s.cmds <- Message{Code: Release}
-
-	// Also inform the state machine it should exit since the internal handler
-	// may override the release message causing the task to be unreleaseable.
-	s.stop()
+	select {
+	case s.cmds <- Message{Code: Release}:
+		// Also inform the state machine it should exit since the internal handler
+		// may override the release message causing the task to be unreleaseable.
+		s.stop()
+	case <-s.stopped:
+		// Already stopped!
+	}
 }
 
 func (s *stateMachine) stop() {

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -57,7 +57,7 @@ func (s *State) copy() *State {
 	return ns
 }
 
-func (s State) String() string {
+func (s *State) String() string {
 	switch s.Code {
 	case Sleeping:
 		return fmt.Sprintf("%s until %s", s.Code, s.Until)
@@ -80,9 +80,19 @@ type Message struct {
 	Err error `json:"error,omitempty"`
 }
 
+// ErrorMessage is a simpler helper for creating error messages from an error.
+func ErrorMessage(err error) Message {
+	return Message{Code: Error, Err: err}
+}
+
+// SleepMessage is a simpler helper for creating sleep messages from a time.
+func SleepMessage(t time.Time) Message {
+	return Message{Code: Sleep, Until: &t}
+}
+
 // Valid returns true if the Message is valid. Invalid messages sent as
 // commands are discarded by the state machine.
-func (m Message) Valid() bool {
+func (m *Message) Valid() bool {
 	switch m.Code {
 	case Run, Pause, Release, Checkpoint, Complete, Kill:
 		return true
@@ -95,7 +105,7 @@ func (m Message) Valid() bool {
 	}
 }
 
-func (m Message) String() string {
+func (m *Message) String() string {
 	switch m.Code {
 	case Sleep:
 		if m.Until != nil {

--- a/statemachine/statestore.go
+++ b/statemachine/statestore.go
@@ -1,5 +1,7 @@
 package statemachine
 
+import "github.com/lytics/metafora"
+
 // StateStore is an interface implementations must provide for persisting task
 // state. Since the task ID is provided on each method call a single global
 // StateStore can be used and implementations should be safe for concurrent
@@ -10,9 +12,9 @@ type StateStore interface {
 	//
 	// The one exception is the special error StateNotFound which will cause the
 	// state machine to start from the initial (Runnable) state.
-	Load(taskID string) (*State, error)
+	Load(metafora.Task) (*State, error)
 
 	// Store the current task state. Errors will prevent current state from being
 	// persisted and prevent state transitions.
-	Store(taskID string, s *State) error
+	Store(metafora.Task, *State) error
 }

--- a/task.go
+++ b/task.go
@@ -6,20 +6,35 @@ import (
 	"time"
 )
 
+// Task is the minimum interface for Tasks to implement.
 type Task interface {
+	// ID is the immutable globally unique ID for this task.
 	ID() string
+}
+
+// RunningTask represents tasks running within a consumer.
+type RunningTask interface {
+	Task() Task
+
+	// Started is the time the task was started by this consumer.
 	Started() time.Time
+
+	// Stopped is the first time Stop() was called on this task or zero is it has
+	// yet to be called. Tasks may take an indeterminate amount of time to
+	// shutdown after Stop() is called.
 	Stopped() time.Time
+
+	// Handler implementation called for this task.
 	Handler() Handler
 }
 
-// task is the per-task state Metafora tracks internally.
-type task struct {
+// runtask is the per-task state Metafora tracks internally.
+type runtask struct {
+	// task is the original Task from the coordinator
+	task Task
+
 	// handler on which Run and Stop are called
 	h Handler
-
-	// id of task to satisfy Task interface
-	id string
 
 	// stopL serializes calls to task.h.Stop() to make handler implementations
 	// easier/safer as well as guard stopped
@@ -30,11 +45,11 @@ type task struct {
 	stopped time.Time
 }
 
-func newTask(id string, h Handler) *task {
-	return &task{id: id, h: h, started: time.Now()}
+func newTask(task Task, h Handler) *runtask {
+	return &runtask{task: task, h: h, started: time.Now()}
 }
 
-func (t *task) stop() {
+func (t *runtask) stop() {
 	t.stopL.Lock()
 	defer t.stopL.Unlock()
 	if t.stopped.IsZero() {
@@ -43,21 +58,21 @@ func (t *task) stop() {
 	t.h.Stop()
 }
 
-func (t *task) ID() string         { return t.id }
-func (t *task) Handler() Handler   { return t.h }
-func (t *task) Started() time.Time { return t.started }
-func (t *task) Stopped() time.Time {
+func (t *runtask) Task() Task         { return t.task }
+func (t *runtask) Handler() Handler   { return t.h }
+func (t *runtask) Started() time.Time { return t.started }
+func (t *runtask) Stopped() time.Time {
 	t.stopL.Lock()
 	defer t.stopL.Unlock()
 	return t.stopped
 }
 
-func (t *task) MarshalJSON() ([]byte, error) {
+func (t *runtask) MarshalJSON() ([]byte, error) {
 	js := struct {
 		ID      string     `json:"id"`
 		Started time.Time  `json:"started"`
 		Stopped *time.Time `json:"stopped,omitempty"`
-	}{ID: t.id, Started: t.started}
+	}{ID: t.task.ID(), Started: t.started}
 
 	// Only set stopped if it's non-zero
 	if s := t.Stopped(); !s.IsZero() {


### PR DESCRIPTION
This allows users to implement coordinator-specific Task structs,
although Balancers and Handlers will have to type assert/switch the
metafora.Task to the cooordinator-specific implementation.

To allow for coordinator reuse with Task implementation variation, the
m_etcd.Coordinator allows users to define a custom NewTask function to
unmarshal the etcd task node into a use case specific struct.

Core Consumer now has a RunningTask interface that wraps the underlying
Task interface so that the struct underlying the Task interface returned
by a Coordinator remains unchanged.