### PR TITLE
Fix etcd command listener for existing commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-script: go test -race -cpu 1,2,4 -v -timeout 2m ./...
+script: ETCDTESTS=1 go test -race -cpu 1,2,4 -v -timeout 2m ./...
 sudo: false
 go:
   - 1.3
@@ -15,3 +15,6 @@ notifications:
     on_success: "change"  # options: [always|never|change] default: always
     on_failure: "always"  # options: [always|never|change] default: always
     on_start: false     # default: false
+before_script:
+  - curl -sL https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz | tar xz
+  - etcd-v2.1.1-linux-amd64/etcd 2> /dev/null &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-script: ETCDTESTS=1 go test -race -cpu 1,2,4 -v -timeout 2m ./...
+script: ETCDTESTS=1 go test -race -cpu 1,2,4 -v -timeout 5m ./...
 sudo: false
 go:
   - 1.3

--- a/m_etcd/commander_test.go
+++ b/m_etcd/commander_test.go
@@ -1,0 +1,67 @@
+package m_etcd_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lytics/metafora"
+	"github.com/lytics/metafora/m_etcd"
+	"github.com/lytics/metafora/m_etcd/testutil"
+	"github.com/lytics/metafora/statemachine"
+)
+
+func TestCommandListener(t *testing.T) {
+	t.Parallel()
+
+	// etcd clients are not safe for concurrent use, so create one for each
+	// component
+	cmdrclient, _ := testutil.NewEtcdClient(t)
+	clclient, _ := testutil.NewEtcdClient(t)
+
+	const recursive = true
+	cmdrclient.Delete("testtask", recursive)
+
+	task := metafora.NewTask("testtask")
+	namespace := "cltest"
+
+	cmdr := m_etcd.NewCommander(namespace, cmdrclient)
+
+	// Only the last command should be received once the listener is started
+	cmdr.Send(task.ID(), statemachine.PauseMessage())
+	cmdr.Send(task.ID(), statemachine.KillMessage())
+
+	cl := m_etcd.NewCommandListener(task, namespace, clclient)
+	defer cl.Stop()
+
+	// Ensure last command was received
+	select {
+	case cmd := <-cl.Receive():
+		if cmd.Code != statemachine.Kill {
+			t.Fatalf("Expected Kill message, received %v", cmd)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("CommandListener took too long to receive message")
+	}
+
+	// Ensure only one command was received
+	select {
+	case cmd := <-cl.Receive():
+		t.Fatalf("Unexpected command received: %v", cmd)
+	case <-time.After(300 * time.Millisecond):
+		// Ok!
+	}
+
+	cl.Stop()
+
+	// Stop doesn't block until watching loop exits, so wait briefly
+	time.Sleep(10 * time.Millisecond)
+
+	// Ensure receiving after Stopping never succeeds
+	cmdr.Send(task.ID(), statemachine.RunMessage())
+	select {
+	case cmd := <-cl.Receive():
+		t.Fatalf("Unexpected command received: %v", cmd)
+	case <-time.After(300 * time.Millisecond):
+		// Ok
+	}
+}

--- a/m_etcd/commander_test.go
+++ b/m_etcd/commander_test.go
@@ -19,10 +19,10 @@ func TestCommandListener(t *testing.T) {
 	clclient, _ := testutil.NewEtcdClient(t)
 
 	const recursive = true
-	cmdrclient.Delete("testtask", recursive)
+	namespace := "cltest"
+	cmdrclient.Delete("/"+namespace, recursive)
 
 	task := metafora.NewTask("testtask")
-	namespace := "cltest"
 
 	cmdr := m_etcd.NewCommander(namespace, cmdrclient)
 

--- a/m_etcd/coordinator_test.go
+++ b/m_etcd/coordinator_test.go
@@ -154,12 +154,12 @@ func TestCoordinatorTC3(t *testing.T) {
 
 	//XXX This assumes tasks are sent by watchers in the order they were
 	//    submitted to etcd which, while /possible/ to guarantee, isn't a gurantee
-	//    we're interested in making. Remove this section if it starts causing problems.
+	//    we're interested in making.
 	//    We only want to guarantee that exactly one coordinator can claim a task.
 	c1t := <-c1tasks
 	c2t := <-c2tasks
 	if c1t.ID() != c2t.ID() {
-		t.Fatalf("Watchers didn't receive the same task %s != %s. Might be fine; see code.", c1t, c2t)
+		t.Logf("Watchers didn't receive the same task %s != %s. It's fine; watch order isn't guaranteed", c1t, c2t)
 	}
 
 	// Make sure c1 can claim and c2 cannot

--- a/m_etcd/task_test.go
+++ b/m_etcd/task_test.go
@@ -31,7 +31,6 @@ func (t *exTask) String() string {
 
 func TestAltTask(t *testing.T) {
 	etcdc, hosts := testutil.NewEtcdClient(t)
-	metafora.SetLogLevel(metafora.LogLevelDebug)
 	t.Parallel()
 	const namespace = "alttask-metafora"
 


### PR DESCRIPTION
The etcd command listener was improperly ignoring commands sent before
the listener was created. It also needed some tests!

I also figured out a way to run etcd on Travis and enable our etcd integration tests. Definitely opens us up to more timing-related test failures, but I'd rather fix them then rely on fast local machines narrowly avoiding them.