### PR TITLE
Lessen etcd load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: go
 script: ETCDTESTS=1 go test -race -cpu 1,2,4 -v -timeout 5m ./...
 sudo: false
 go:
-  - 1.3
-  - 1.4
+  - 1.3.3
+  - 1.4.2
+  - 1.5.1
   - tip
 matrix:
   allow_failures:
@@ -16,5 +17,5 @@ notifications:
     on_failure: "always"  # options: [always|never|change] default: always
     on_start: false     # default: false
 before_script:
-  - curl -sL https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz | tar xz
-  - etcd-v2.1.1-linux-amd64/etcd 2> /dev/null &
+  - curl -sL https://github.com/coreos/etcd/releases/download/v2.1.3/etcd-v2.1.3-linux-amd64.tar.gz | tar xz
+  - etcd-v2.1.3-linux-amd64/etcd 2> /dev/null &

--- a/embedded/embedded_test.go
+++ b/embedded/embedded_test.go
@@ -1,12 +1,18 @@
 package embedded
 
 import (
+	"log"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/lytics/metafora"
 )
+
+func init() {
+	metafora.SetLogger(log.New(os.Stderr, "", log.Lmicroseconds|log.Lshortfile))
+}
 
 func TestEmbedded(t *testing.T) {
 

--- a/examples/koalemosd/main.go
+++ b/examples/koalemosd/main.go
@@ -16,10 +16,11 @@ import (
 
 func main() {
 	mlvl := metafora.LogLevelInfo
+	hostname, _ := os.Hostname()
 
 	peers := flag.String("etcd", "http://127.0.0.1:2379", "comma delimited etcd peer list")
 	namespace := flag.String("namespace", "koalemos", "metafora namespace")
-	name := flag.String("name", "", "node name or empty for automatic")
+	name := flag.String("name", hostname, "node name or empty for automatic")
 	loglvl := flag.String("log", mlvl.String(), "set log level: [debug], info, warn, error")
 	flag.Parse()
 
@@ -40,10 +41,7 @@ func main() {
 	}
 	metafora.SetLogLevel(mlvl)
 
-	conf := m_etcd.NewConfig(*namespace, hosts)
-	if *name != "" {
-		conf.Name = *name
-	}
+	conf := m_etcd.NewConfig(*name, *namespace, hosts)
 
 	// Replace NewTask func with one that returns a *koalemos.Task
 	conf.NewTaskFunc = func(id, value string) metafora.Task {

--- a/examples/koalemosd/main.go
+++ b/examples/koalemosd/main.go
@@ -40,14 +40,13 @@ func main() {
 	}
 	metafora.SetLogLevel(mlvl)
 
-	hfunc := makeHandlerFunc(etcdc)
-	ec, err := m_etcd.NewEtcdCoordinator(*name, *namespace, hosts)
-	if err != nil {
-		metafora.Errorf("Error creating etcd coordinator: %v", err)
+	conf := m_etcd.NewConfig(*namespace, hosts)
+	if *name != "" {
+		conf.Name = *name
 	}
 
 	// Replace NewTask func with one that returns a *koalemos.Task
-	ec.NewTask = func(id, value string) metafora.Task {
+	conf.NewTaskFunc = func(id, value string) metafora.Task {
 		t := koalemos.NewTask(id)
 		if value == "" {
 			return t
@@ -59,7 +58,13 @@ func main() {
 		return t
 	}
 
-	bal := m_etcd.NewFairBalancer(*name, *namespace, hosts)
+	hfunc := makeHandlerFunc(etcdc)
+	ec, err := m_etcd.NewEtcdCoordinator(conf)
+	if err != nil {
+		metafora.Errorf("Error creating etcd coordinator: %v", err)
+	}
+
+	bal := m_etcd.NewFairBalancer(conf)
 	c, err := metafora.NewConsumer(ec, hfunc, bal)
 	if err != nil {
 		metafora.Errorf("Error creating consumer: %v", err)
@@ -67,7 +72,7 @@ func main() {
 	}
 	metafora.Infof(
 		"Starting koalsmosd with etcd=%s; namespace=%s; name=%s; loglvl=%s",
-		*peers, *namespace, ec.NodeID, mlvl)
+		*peers, conf.Namespace, conf.Name, mlvl)
 	consumerRunning := make(chan struct{})
 	go func() {
 		defer close(consumerRunning)

--- a/m_etcd/balancer.go
+++ b/m_etcd/balancer.go
@@ -3,7 +3,6 @@ package m_etcd
 import (
 	"encoding/json"
 	"path"
-	"strings"
 
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/lytics/metafora"
@@ -11,15 +10,14 @@ import (
 
 // NewFairBalancer creates a new metafora.DefaultFairBalancer that uses etcd
 // for counting tasks per node.
-func NewFairBalancer(nodeid, namespace string, hosts []string) metafora.Balancer {
-	namespace = "/" + strings.Trim(namespace, "/ ")
-	client, _ := newEtcdClient(hosts)
+func NewFairBalancer(conf *Config) metafora.Balancer {
+	client, _ := newEtcdClient(conf.Hosts)
 	e := etcdClusterState{
 		client:   client,
-		taskPath: path.Join(namespace, "tasks"),
-		nodePath: path.Join(namespace, "nodes"),
+		taskPath: path.Join(conf.Namespace, NodesPath),
+		nodePath: path.Join(conf.Namespace, TasksPath),
 	}
-	return metafora.NewDefaultFairBalancer(nodeid, &e)
+	return metafora.NewDefaultFairBalancer(conf.Name, &e)
 }
 
 // Checks the current state of an Etcd cluster

--- a/m_etcd/balancer_test.go
+++ b/m_etcd/balancer_test.go
@@ -46,7 +46,7 @@ func TestFairBalancer(t *testing.T) {
 	cli.SubmitTask(DefaultTaskFunc("t5", ""))
 	cli.SubmitTask(DefaultTaskFunc("t6", ""))
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	if len(con1.Tasks()) != 6 {
 		t.Fatalf("con1 should have claimed 6 tasks: %d", len(con1.Tasks()))
@@ -57,7 +57,7 @@ func TestFairBalancer(t *testing.T) {
 	defer con2.Shutdown()
 
 	// Wait for node to startup and register
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	cli.SubmitCommand(conf1.Name, metafora.CommandBalance())
 

--- a/m_etcd/client.go
+++ b/m_etcd/client.go
@@ -46,7 +46,7 @@ func (mc *mclient) SubmitTask(task metafora.Task) error {
 	if err != nil {
 		return err
 	}
-	if _, err := mc.etcd.Create(fullpath, string(buf), ForeverTTL); err != nil {
+	if _, err := mc.etcd.Create(fullpath, string(buf), foreverTTL); err != nil {
 		return err
 	}
 	metafora.Debugf("task %s submitted: %s", task.ID(), fullpath)
@@ -72,7 +72,7 @@ func (mc *mclient) SubmitCommand(node string, command metafora.Command) error {
 		// command incorrectly.
 		return err
 	}
-	if _, err := mc.etcd.AddChild(cmdPath, string(body), ForeverTTL); err != nil {
+	if _, err := mc.etcd.AddChild(cmdPath, string(body), foreverTTL); err != nil {
 		metafora.Errorf("Error submitting command: %s to node: %s", command, node)
 		return err
 	}

--- a/m_etcd/conf.go
+++ b/m_etcd/conf.go
@@ -2,14 +2,13 @@ package m_etcd
 
 import (
 	"fmt"
-	"math/rand"
-	"os"
 	"strings"
-	"time"
 )
 
 type Config struct {
 	// Namespace is the key prefix to allow for multitenant use of etcd.
+	//
+	// Namespaces must start with a / (added by NewConfig if needed).
 	Namespace string
 
 	// Name of this Metafora consumer. Only one instance of a Name is allowed to
@@ -47,18 +46,12 @@ type Config struct {
 // the others.
 //
 // Panics on empty values.
-func NewConfig(namespace string, hosts []string) *Config {
-	if len(hosts) == 0 || namespace == "" {
+func NewConfig(name, namespace string, hosts []string) *Config {
+	if len(hosts) == 0 || namespace == "" || name == "" {
 		panic("invalid etcd config")
 	}
 
 	namespace = "/" + strings.Trim(namespace, "/ ")
-
-	hn, err := os.Hostname()
-	if err != nil {
-		panic("error getting hostname: " + err.Error())
-	}
-	name := fmt.Sprintf("%s-%x", hn, rand.New(rand.NewSource(time.Now().UnixNano())).Int63())
 
 	return &Config{
 		Name:        name,

--- a/m_etcd/conf.go
+++ b/m_etcd/conf.go
@@ -1,0 +1,87 @@
+package m_etcd
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	// Namespace is the key prefix to allow for multitenant use of etcd.
+	Namespace string
+
+	// Name of this Metafora consumer. Only one instance of a Name is allowed to
+	// run in a Namespace at a time, so if you set the Name to hostname you can
+	// effectively limit Metafora to one process per server.
+	Name string
+
+	// Hosts are the URLs to create etcd clients with.
+	Hosts []string
+
+	// ClaimTTL is the timeout on task claim markers in seconds.
+	//
+	// Since every task must update its claim before the TTL expires, setting
+	// this lower will increase the load on etcd. Setting this setting higher
+	// increases the amount of time it takes a task to be rescheduled if the node
+	// it was running on shutsdown uncleanly (or is separated by a network
+	// partition).
+	//
+	// If 0 it is set to DefaultClaimTTL
+	ClaimTTL uint64
+
+	// NodeTTL is the timeout on the node's name entry in seconds.
+	//
+	// If 0 it is set to DefaultNodeTTL
+	NodeTTL uint64
+
+	// NewTaskFunc is the function called to unmarshal tasks from etcd into a
+	// custom struct. The struct must implement the metafora.Task interface.
+	//
+	// If nil it is set to DefaultTaskFunc
+	NewTaskFunc TaskFunc
+}
+
+// NewConfig creates a Config with the required fields and uses defaults for
+// the others.
+//
+// Panics on empty values.
+func NewConfig(namespace string, hosts []string) *Config {
+	if len(hosts) == 0 || namespace == "" {
+		panic("invalid etcd config")
+	}
+
+	namespace = "/" + strings.Trim(namespace, "/ ")
+
+	hn, err := os.Hostname()
+	if err != nil {
+		panic("error getting hostname: " + err.Error())
+	}
+	name := fmt.Sprintf("%s-%x", hn, rand.New(rand.NewSource(time.Now().UnixNano())).Int63())
+
+	return &Config{
+		Name:        name,
+		Namespace:   namespace,
+		Hosts:       hosts,
+		ClaimTTL:    DefaultClaimTTL,
+		NodeTTL:     DefaultNodeTTL,
+		NewTaskFunc: DefaultTaskFunc,
+	}
+}
+
+// Copy returns a shallow copy of this config.
+func (c *Config) Copy() *Config {
+	return &Config{
+		Name:        c.Name,
+		Namespace:   c.Namespace,
+		Hosts:       c.Hosts,
+		ClaimTTL:    c.ClaimTTL,
+		NodeTTL:     c.NodeTTL,
+		NewTaskFunc: c.NewTaskFunc,
+	}
+}
+
+func (c *Config) String() string {
+	return fmt.Sprintf("etcd:%s/%s", c.Namespace, c.Name)
+}

--- a/m_etcd/const.go
+++ b/m_etcd/const.go
@@ -8,7 +8,7 @@ const (
 	OwnerMarker  = "owner"
 	PropsKey     = "props"
 
-	ForeverTTL = 0 //Ref: https://github.com/coreos/go-etcd/blob/e10c58ee110f54c2f385ac99764e8a7ca4cb13df/etcd/requests.go#L356
+	foreverTTL = 0 //Ref: https://github.com/coreos/go-etcd/blob/e10c58ee110f54c2f385ac99764e8a7ca4cb13df/etcd/requests.go#L356
 
 	//Etcd Error codes are passed directly through go-etcd from the http response,
 	//So to find the error codes use this ref:

--- a/m_etcd/const.go
+++ b/m_etcd/const.go
@@ -1,6 +1,9 @@
 package m_etcd
 
 const (
+	DefaultClaimTTL uint64 = 120 // seconds
+	DefaultNodeTTL  uint64 = 20  // seconds
+
 	TasksPath    = "tasks"
 	NodesPath    = "nodes"
 	CommandsPath = "commands"

--- a/m_etcd/const.go
+++ b/m_etcd/const.go
@@ -1,8 +1,8 @@
 package m_etcd
 
 const (
-	DefaultClaimTTL uint64 = 120 // seconds
-	DefaultNodeTTL  uint64 = 20  // seconds
+	DefaultClaimTTL uint64 = 180 // 3 minutes in seconds
+	DefaultNodeTTL  uint64 = 60  // seconds
 
 	TasksPath    = "tasks"
 	NodesPath    = "nodes"

--- a/m_etcd/coordinator.go
+++ b/m_etcd/coordinator.go
@@ -178,8 +178,8 @@ func (ec *EtcdCoordinator) Init(cordCtx metafora.CoordinatorContext) error {
 
 	ec.cordCtx = cordCtx
 
-	ec.upsertDir(ec.namespace, ForeverTTL)
-	ec.upsertDir(ec.taskPath, ForeverTTL)
+	ec.upsertDir(ec.namespace, foreverTTL)
+	ec.upsertDir(ec.taskPath, foreverTTL)
 	if _, err := ec.client.CreateDir(ec.nodePath, ec.nodePathTTL); err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func (ec *EtcdCoordinator) Init(cordCtx metafora.CoordinatorContext) error {
 
 	// Start goroutine to heartbeat node key in etcd
 	go ec.nodeRefresher()
-	ec.upsertDir(ec.commandPath, ForeverTTL)
+	ec.upsertDir(ec.commandPath, foreverTTL)
 
 	ec.taskManager = newManager(cordCtx, tmc, ec.taskPath, ec.NodeID, ec.ClaimTTL)
 	return nil

--- a/m_etcd/helpers_test.go
+++ b/m_etcd/helpers_test.go
@@ -27,7 +27,7 @@ func setupEtcd(t *testing.T) (*EtcdCoordinator, *Config) {
 	n := atomic.AddUint64(&testcounter, 1)
 	ns := fmt.Sprintf("metaforatests-%d", n)
 	client.Delete(ns, recursive)
-	conf := NewConfig(ns, hosts)
+	conf := NewConfig("testclient", ns, hosts)
 	coord, err := NewEtcdCoordinator(conf)
 	if err != nil {
 		t.Fatalf("Error creating etcd coordinator: %v", err)

--- a/m_etcd/helpers_test.go
+++ b/m_etcd/helpers_test.go
@@ -2,6 +2,8 @@ package m_etcd
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -9,7 +11,9 @@ import (
 	"github.com/lytics/metafora/m_etcd/testutil"
 )
 
-const namespace = "/metaforatests"
+func init() {
+	metafora.SetLogger(log.New(os.Stderr, "", log.Lmicroseconds|log.Lshortfile))
+}
 
 var testcounter uint64
 
@@ -21,7 +25,7 @@ var testcounter uint64
 func setupEtcd(t *testing.T) (*EtcdCoordinator, *Config) {
 	client, hosts := testutil.NewEtcdClient(t)
 	n := atomic.AddUint64(&testcounter, 1)
-	ns := fmt.Sprintf("%s-%d", namespace, n)
+	ns := fmt.Sprintf("metaforatests-%d", n)
 	client.Delete(ns, recursive)
 	conf := NewConfig(ns, hosts)
 	coord, err := NewEtcdCoordinator(conf)

--- a/m_etcd/helpers_test.go
+++ b/m_etcd/helpers_test.go
@@ -2,31 +2,33 @@ package m_etcd
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/lytics/metafora"
 	"github.com/lytics/metafora/m_etcd/testutil"
 )
 
-const (
-	namespace = "/metaforatests"
-	nodeID    = "node1"
-)
+const namespace = "/metaforatests"
+
+var testcounter uint64
 
 // setupEtcd should be used for all etcd integration tests. It handles the following tasks:
 //  * Skip tests if ETCDTESTS is unset
 //  * Create and return an etcd client
 //  * Create and return an initial etcd coordinator
 //  * Clearing the test namespace in etcd
-func setupEtcd(t *testing.T) (*EtcdCoordinator, []string) {
+func setupEtcd(t *testing.T) (*EtcdCoordinator, *Config) {
 	client, hosts := testutil.NewEtcdClient(t)
-	const recursive = true
-	client.Delete(namespace, recursive)
-	coord, err := NewEtcdCoordinator(nodeID, namespace, hosts)
+	n := atomic.AddUint64(&testcounter, 1)
+	ns := fmt.Sprintf("%s-%d", namespace, n)
+	client.Delete(ns, recursive)
+	conf := NewConfig(ns, hosts)
+	coord, err := NewEtcdCoordinator(conf)
 	if err != nil {
 		t.Fatalf("Error creating etcd coordinator: %v", err)
 	}
-	return coord, hosts
+	return coord, conf
 }
 
 type testLogger struct {

--- a/m_etcd/integration_test.go
+++ b/m_etcd/integration_test.go
@@ -274,7 +274,7 @@ func TestAll(t *testing.T) {
 		}
 
 		// Give them time to start
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(time.Second)
 
 		n := len(cons1b.Tasks()) + len(cons2b.Tasks())
 		if n != 3 {
@@ -287,7 +287,7 @@ func TestAll(t *testing.T) {
 			if err := cmdr.Send("error-test", statemachine.RunMessage()); err != nil {
 				t.Fatalf("Unexpected error resuming error-test in B: %v", err)
 			}
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 		}
 
 		n = len(cons1b.Tasks()) + len(cons2b.Tasks())
@@ -301,7 +301,7 @@ func TestAll(t *testing.T) {
 		}
 
 		// Give the statemachine a moment to load the initial state and exit
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(time.Second)
 
 		n = len(cons1b.Tasks()) + len(cons2b.Tasks())
 		if n != 2 {

--- a/m_etcd/integration_test.go
+++ b/m_etcd/integration_test.go
@@ -42,7 +42,9 @@ func TestSleepTest(t *testing.T) {
 	}
 
 	newC := func(name, ns string) *metafora.Consumer {
-		coord, hf, bal, err := m_etcd.New(name, ns, hosts, h)
+		conf := m_etcd.NewConfig(ns, hosts)
+		conf.Name = name
+		coord, hf, bal, err := m_etcd.New(conf, h)
 		if err != nil {
 			t.Fatalf("Error creating new etcd stack: %v", err)
 		}
@@ -144,7 +146,9 @@ func TestAll(t *testing.T) {
 	}
 
 	newC := func(name, ns string) *metafora.Consumer {
-		coord, hf, bal, err := m_etcd.New(name, ns, hosts, h)
+		conf := m_etcd.NewConfig(ns, hosts)
+		conf.Name = name
+		coord, hf, bal, err := m_etcd.New(conf, h)
 		if err != nil {
 			t.Fatalf("Error creating new etcd stack: %v", err)
 		}
@@ -341,7 +345,8 @@ func TestTaskResurrectionInt(t *testing.T) {
 
 	task := m_etcd.DefaultTaskFunc("xyz", "")
 
-	coord, err := m_etcd.NewEtcdCoordinator("r-node", "test-resurrect", hosts)
+	conf := m_etcd.NewConfig("test-resurrect", hosts)
+	coord, err := m_etcd.NewEtcdCoordinator(conf)
 	if err != nil {
 		t.Fatalf("Error creating coordinator: %v", err)
 	}

--- a/m_etcd/integration_test.go
+++ b/m_etcd/integration_test.go
@@ -42,8 +42,7 @@ func TestSleepTest(t *testing.T) {
 	}
 
 	newC := func(name, ns string) *metafora.Consumer {
-		conf := m_etcd.NewConfig(ns, hosts)
-		conf.Name = name
+		conf := m_etcd.NewConfig(name, ns, hosts)
 		coord, hf, bal, err := m_etcd.New(conf, h)
 		if err != nil {
 			t.Fatalf("Error creating new etcd stack: %v", err)
@@ -146,7 +145,7 @@ func TestAll(t *testing.T) {
 	}
 
 	newC := func(name, ns string) *metafora.Consumer {
-		conf := m_etcd.NewConfig(ns, hosts)
+		conf := m_etcd.NewConfig(name, ns, hosts)
 		conf.Name = name
 		coord, hf, bal, err := m_etcd.New(conf, h)
 		if err != nil {
@@ -345,7 +344,7 @@ func TestTaskResurrectionInt(t *testing.T) {
 
 	task := m_etcd.DefaultTaskFunc("xyz", "")
 
-	conf := m_etcd.NewConfig("test-resurrect", hosts)
+	conf := m_etcd.NewConfig("testclient", "test-resurrect", hosts)
 	coord, err := m_etcd.NewEtcdCoordinator(conf)
 	if err != nil {
 		t.Fatalf("Error creating coordinator: %v", err)

--- a/m_etcd/parse_test.go
+++ b/m_etcd/parse_test.go
@@ -45,7 +45,7 @@ func TestParseTask(t *testing.T) {
 
 	// Unfortunately parseTasks sometimes has to go back out to etcd for
 	// properties. Insert test data.
-	etcdc.Create("/test-parse/tasks/0/props", "{invalid", ForeverTTL)
+	etcdc.Create("/test-parse/tasks/0/props", "{invalid", foreverTTL)
 
 	tests := []taskTest{
 		// bad

--- a/m_etcd/statestore.go
+++ b/m_etcd/statestore.go
@@ -64,6 +64,6 @@ func (s *stateStore) Store(task metafora.Task, state *statemachine.State) error 
 		return err
 	}
 
-	_, err = s.c.Set(path.Join(s.path, task.ID()), string(buf), ForeverTTL)
+	_, err = s.c.Set(path.Join(s.path, task.ID()), string(buf), foreverTTL)
 	return err
 }

--- a/m_etcd/task_test.go
+++ b/m_etcd/task_test.go
@@ -36,6 +36,17 @@ func TestAltTask(t *testing.T) {
 
 	etcdc.Delete(namespace, recursive)
 
+	conf := m_etcd.NewConfig(namespace, hosts)
+
+	// Sample overridden NewTask func
+	conf.NewTaskFunc = func(id, props string) metafora.Task {
+		task := exTask{id: id}
+		if err := json.Unmarshal([]byte(props), &task); err != nil {
+			metafora.Warnf("%s properties could not be unmarshalled: %v", id, err)
+		}
+		return &task
+	}
+
 	// Create a handler that returns results through a chan for synchronization
 	results := make(chan string, 1)
 
@@ -53,18 +64,9 @@ func TestAltTask(t *testing.T) {
 		return statemachine.PauseMessage()
 	}
 
-	coord, hf, bal, err := m_etcd.New("node1", namespace, hosts, h)
+	coord, hf, bal, err := m_etcd.New(conf, h)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	// Sample overridden NewTask func
-	coord.(*m_etcd.EtcdCoordinator).NewTask = func(id, props string) metafora.Task {
-		task := exTask{id: id}
-		if err := json.Unmarshal([]byte(props), &task); err != nil {
-			metafora.Warnf("%s properties could not be unmarshalled: %v", id, err)
-		}
-		return &task
 	}
 
 	consumer, err := metafora.NewConsumer(coord, hf, bal)

--- a/m_etcd/task_test.go
+++ b/m_etcd/task_test.go
@@ -36,7 +36,7 @@ func TestAltTask(t *testing.T) {
 
 	etcdc.Delete(namespace, recursive)
 
-	conf := m_etcd.NewConfig(namespace, hosts)
+	conf := m_etcd.NewConfig("testclient", namespace, hosts)
 
 	// Sample overridden NewTask func
 	conf.NewTaskFunc = func(id, props string) metafora.Task {

--- a/statemachine/run_test.go
+++ b/statemachine/run_test.go
@@ -44,10 +44,9 @@ func TestCommandBlackhole(t *testing.T) {
 	// Ignore the return message, the point is to make sure it doesn't intercept
 	// further commands.
 	run(f, task("test-task"), cmds)
+	<-rdy
 
 	go func() { cmds <- RunMessage() }()
-
-	<-rdy
 
 	select {
 	case <-cmds:

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,14 @@
 package metafora
 
-import "errors"
+import (
+	"errors"
+	"log"
+	"os"
+)
+
+func init() {
+	SetLogger(log.New(os.Stderr, "", log.Lmicroseconds|log.Lshortfile))
+}
 
 //TODO Move out into a testutil package for other packages to use. The problem
 //is that existing metafora tests would have to be moved to the metafora_test


### PR DESCRIPTION
The big functional change in this PR is to bump the TTLs for claims and nodes keys in etcd.
see: https://github.com/lytics/metafora/pull/145/files#diff-3b20c32ce08787bae06461304543c2ce

* I bumped `ClaimTTL` to lessen the load on our etcd cluster.
* I bumped `NodeTTL` to make us more resilient to brief network partitions.

The only downside to higher TTLs is that if a metafora crashes it will be longer before the tasks it had claimed are picked up by others. Given the rarity of this event, 3 minutes seems like a reasonably short period of time.

However the bulk of this PR is switching to a Config struct for the etcd related components. Before the TTLs were globals which made testing difficult and is just an awkward way to treat such important values.

The Config struct makes it a lot more obvious how to configure Metafora. It's not perfect, but I think it's a step in the right direction.


Lytics employees can see the `metafora-config` branch on our internal repo to see how it's changed.