### PR TITLE
allowing state loaders to release the task, during a DB outage or net…

### DIFF
--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -326,7 +326,7 @@ func (s *stateMachine) Run() (done bool) {
 	state, err := s.ss.Load(s.task)
 	if err == ReleasableError {
 		// A failure to load was reported by our provided loader, but the loader believed the failure
-		// was retiable. In most cases this will be some type of network partition or communication error,
+		// was retriable. In most cases this will be some type of network partition or communication error,
 		// too many file handles, etc.
 		metafora.Errorf("task=%q could not load initial state but the task is retriable!", tid)
 		time.Sleep(time.Second) //defer releasing the task so other nodes don't thunder herd retrying it.

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -13,6 +13,7 @@ import (
 var (
 	MissingUntilError  = errors.New("sleeping state missing deadline")
 	MissingErrorsError = errors.New("fault state has no errors")
+	ReleasableError    = errors.New("network error, release and retry")
 )
 
 // StateCode is the actual state key. The State struct adds additional metadata
@@ -323,7 +324,13 @@ func (s *stateMachine) Run() (done bool) {
 
 	// Load the initial state
 	state, err := s.ss.Load(s.task)
-	if err != nil {
+	if err == ReleasableError {
+		// A failure to load was reported by our provided loader, but the loader believed the failure
+		// was retiable. In most cases this will be some type of network partition or communication error,
+		// too many file handles, etc.
+		metafora.Errorf("task=%q could not load initial state but is retriable !", tid)
+		return false
+	} else if err != nil {
 		// A failure to load the state for a task is *fatal* - the task will be
 		// unscheduled and requires operator intervention to reschedule.
 		metafora.Errorf("task=%q could not load initial state. Marking done! Error: %v", tid, err)
@@ -332,7 +339,7 @@ func (s *stateMachine) Run() (done bool) {
 	if state == nil {
 		// Note to StateStore implementors: This should not happen! Either state or
 		// err must be non-nil. This code is simply to prevent a nil pointer panic.
-		metafora.Errorf("statestore %T returned nil state and err for task=%q - unscheduling")
+		metafora.Errorf("statestore %T returned nil state and err for task=%q - unscheduling", s.ss, tid)
 		return true
 	}
 	if state.Code.Terminal() {

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -328,7 +328,8 @@ func (s *stateMachine) Run() (done bool) {
 		// A failure to load was reported by our provided loader, but the loader believed the failure
 		// was retiable. In most cases this will be some type of network partition or communication error,
 		// too many file handles, etc.
-		metafora.Errorf("task=%q could not load initial state but is retriable !", tid)
+		metafora.Errorf("task=%q could not load initial state but the task is retriable!", tid)
+		time.Sleep(time.Second) //defer releasing the task so other nodes don't thunder herd retrying it.
 		return false
 	} else if err != nil {
 		// A failure to load the state for a task is *fatal* - the task will be


### PR DESCRIPTION
allow state loaders to return a sentinel error, if they want to release the task instead of marking it as complete.  