### PR TITLE
Add ability to filter out nodes from the balancer queries

### DIFF
--- a/examples/koalemosd/main.go
+++ b/examples/koalemosd/main.go
@@ -73,7 +73,8 @@ func main() {
 		metafora.Errorf("Error creating etcd coordinator: %v", err)
 	}
 
-	bal := metcdv3.NewFairBalancer(conf, etcdv3c)
+	filter := func(_ *metcdv3.FilterableValue) bool { return true }
+	bal := metcdv3.NewFairBalancer(conf, etcdv3c, filter)
 	c, err := metafora.NewConsumer(ec, hfunc, bal)
 	if err != nil {
 		metafora.Errorf("Error creating consumer: %v", err)

--- a/metcdv3/balancer_test.go
+++ b/metcdv3/balancer_test.go
@@ -24,14 +24,15 @@ func TestFairBalancer(t *testing.T) {
 		return false // never done
 	})
 
+	filter := func(_ *FilterableValue) bool { return true }
 	// Create two consumers
-	b1 := NewFairBalancer(conf1, etcdv3c)
+	b1 := NewFairBalancer(conf1, etcdv3c, filter)
 	con1, err := metafora.NewConsumer(coord1, h, b1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	b2 := NewFairBalancer(conf2, etcdv3c)
+	b2 := NewFairBalancer(conf2, etcdv3c, filter)
 	con2, err := metafora.NewConsumer(coord2, h, b2)
 	if err != nil {
 		t.Fatal(err)
@@ -126,14 +127,15 @@ func TestFairBalancerShutdown(t *testing.T) {
 		return false // never done
 	})
 
+	filter := func(_ *FilterableValue) bool { return true }
 	// Create two consumers
-	b1 := NewFairBalancer(conf1, etcdv3c)
+	b1 := NewFairBalancer(conf1, etcdv3c, filter)
 	con1, err := metafora.NewConsumer(coord1, h1, b1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	b2 := NewFairBalancer(conf2, etcdv3c)
+	b2 := NewFairBalancer(conf2, etcdv3c, filter)
 	con2, err := metafora.NewConsumer(coord2, h2, b2)
 	if err != nil {
 		t.Fatal(err)

--- a/metcdv3/coordinator.go
+++ b/metcdv3/coordinator.go
@@ -56,8 +56,9 @@ func New(conf *Config, etcdv3c *etcdv3.Client, h statemachine.StatefulHandler) (
 	// Create an etcd coordinator
 	coord := NewEtcdV3Coordinator(conf, etcdv3c)
 
+	filter := func(_ *FilterableValue) bool { return true }
 	// Create an etcd backed Fair Balancer (there's no harm in not using it)
-	bal := NewFairBalancer(conf, etcdv3c)
+	bal := NewFairBalancer(conf, etcdv3c, filter)
 	return coord, hf, bal
 }
 


### PR DESCRIPTION
This commit adds the ability to pass in a function to the fairbalancer
for etcdv3 metafora balancer that will filter out nodes you don't want
to balance across. This will allow us to isolate balancing to canary and
non-canary deployments of metafora.

This commit also updates the package path for etcd now that it has moved
gihub orgs.