### PR TITLE
Fix  based on best practices from Effective Go

### DIFF
--- a/embedded/util.go
+++ b/embedded/util.go
@@ -7,7 +7,7 @@ type NodeCommand struct {
 	NodeId string
 }
 
-// Returns a connected client/coordinator pair for embedded/testing use
+// NewEmbeddedPair returns a connected client/coordinator pair for embedded/testing use
 func NewEmbeddedPair(nodeid string) (metafora.Coordinator, metafora.Client) {
 	taskchan := make(chan metafora.Task)
 	cmdchan := make(chan *NodeCommand)

--- a/handler.go
+++ b/handler.go
@@ -36,7 +36,7 @@ type Handler interface {
 // of work necessary to initialize a handler should be done.
 type HandlerFunc func(Task) Handler
 
-// SimpleHander creates a HandlerFunc for a simple function that accepts a stop
+// SimpleHandler creates a HandlerFunc for a simple function that accepts a stop
 // channel. The channel will be closed when Stop is called.
 func SimpleHandler(f func(t Task, stop <-chan bool) bool) HandlerFunc {
 	return func(t Task) Handler {

--- a/metcdv3/coordinator.go
+++ b/metcdv3/coordinator.go
@@ -388,7 +388,7 @@ func (ec *EtcdV3Coordinator) Name() string {
 	return ec.name
 }
 
-// Start an mclient.
+// Init starts an mclient.
 func (ec *EtcdV3Coordinator) Init(cordCtx metafora.CoordinatorContext) error {
 	ec.cordCtx = cordCtx
 

--- a/metcdv3/testutil/testutil.go
+++ b/metcdv3/testutil/testutil.go
@@ -21,7 +21,7 @@ type TestCase interface {
 	Fatalf(format string, args ...interface{})
 }
 
-// NewEtcdClient creates a new etcd client for use by the metafora client during testing.
+// NewEtcdV3Client creates a new etcd client for use by the metafora client during testing.
 func NewEtcdV3Client(t TestCase) *etcdv3.Client {
 	if os.Getenv("ETCDTESTS") == "" {
 		t.Skip("ETCDTESTS unset. Skipping etcd tests.")


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?