### PR TITLE
implement error interface for statemachine.Err

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
 script: go test -race -cpu 1,2,4 -v -timeout 5m ./...
 sudo: false
 go:
-  - 1.12.x
   - 1.13.x
 notifications:
   webhooks:

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/prometheus/common v0.7.0 // indirect
 	github.com/prometheus/procfs v0.0.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	go.etcd.io/etcd v0.0.0-20190917205325-a14579fbfb1a
 	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lytics/metafora
 
-go 1.12
+go 1.13
 
 require (
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,7 @@ github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=

--- a/statemachine/errors.go
+++ b/statemachine/errors.go
@@ -34,10 +34,9 @@ func (e Err) Error() string {
 	return e.Err
 }
 
-// As implements the error interface for Err. This allows an instance of Err to be
-// converted back to its underlying error type using errors.As
-func (e Err) As(target interface{}) bool {
-	return errors.As(e.baseErr, target)
+// Unwrap returns baseErr.
+func (e Err) Unwrap() error {
+	return e.baseErr
 }
 
 // ErrHandler functions should return Run, Sleep, or Fail messages depending on

--- a/statemachine/errors.go
+++ b/statemachine/errors.go
@@ -13,22 +13,29 @@ import (
 var ExceededErrorRate = errors.New("exceeded error rate")
 
 // Err represents an error that occurred while a stateful handler was running.
+//
+// NewErr was added to allow callers to construct an instance from an underlying error.
+// The underlying error is now preserved so that Err can be converted back using errors.As
+// This is useful for custom error handlers that wish to inspect underlying error types
+// and decision accordingly.
 type Err struct {
 	Time    time.Time `json:"timestamp"`
 	Err     string    `json:"error"`
 	baseErr error
 }
 
-// NewErr constructs an Err
+// NewErr constructs an Err from an underlying error e
 func NewErr(e error, t time.Time) Err {
 	return Err{Err: e.Error(), Time: t, baseErr: e}
 }
 
+// Error implements the Error interface for Err
 func (e Err) Error() string {
 	return e.Err
 }
 
-// As implements the error interface for Err
+// As implements the error interface for Err. This allows an instance of Err to be
+// converted back to its underlying error type using errors.As
 func (e Err) As(target interface{}) bool {
 	return errors.As(e.baseErr, target)
 }

--- a/statemachine/errors.go
+++ b/statemachine/errors.go
@@ -24,7 +24,7 @@ type Err struct {
 	baseErr error
 }
 
-// NewErr constructs an Err from an underlying error e
+// NewErr constructs an Err from an underlying error e.
 func NewErr(e error, t time.Time) Err {
 	return Err{Err: e.Error(), Time: t, baseErr: e}
 }

--- a/statemachine/errors.go
+++ b/statemachine/errors.go
@@ -16,17 +16,21 @@ var ExceededErrorRate = errors.New("exceeded error rate")
 type Err struct {
 	Time    time.Time `json:"timestamp"`
 	Err     string    `json:"error"`
-	error
+	baseErr error
 }
 
 // NewErr constructs an Err
 func NewErr(e error, t time.Time) Err {
-	return Err{Err: e.Error(), Time: t, error: e}
+	return Err{Err: e.Error(), Time: t, baseErr: e}
+}
+
+func (e Err) Error() string {
+	return e.Err
 }
 
 // As implements the error interface for Err
 func (e Err) As(target interface{}) bool {
-	return errors.As(e.error, target)
+	return errors.As(e.baseErr, target)
 }
 
 // ErrHandler functions should return Run, Sleep, or Fail messages depending on

--- a/statemachine/errors.go
+++ b/statemachine/errors.go
@@ -14,8 +14,19 @@ var ExceededErrorRate = errors.New("exceeded error rate")
 
 // Err represents an error that occurred while a stateful handler was running.
 type Err struct {
-	Time time.Time `json:"timestamp"`
-	Err  string    `json:"error"`
+	Time    time.Time `json:"timestamp"`
+	Err     string    `json:"error"`
+	error
+}
+
+// NewErr constructs an Err
+func NewErr(e error, t time.Time) Err {
+	return Err{Err: e.Error(), Time: t, error: e}
+}
+
+// As implements the error interface for Err
+func (e Err) As(target interface{}) bool {
+	return errors.As(e.error, target)
 }
 
 // ErrHandler functions should return Run, Sleep, or Fail messages depending on

--- a/statemachine/errors.go
+++ b/statemachine/errors.go
@@ -29,7 +29,7 @@ func NewErr(e error, t time.Time) Err {
 	return Err{Err: e.Error(), Time: t, baseErr: e}
 }
 
-// Error implements the Error interface for Err
+// Error implements the Error interface.
 func (e Err) Error() string {
 	return e.Err
 }

--- a/statemachine/errors_test.go
+++ b/statemachine/errors_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/lytics/metafora/statemachine"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type task string
@@ -46,7 +47,7 @@ func TestDefaultErrHandler(t *testing.T) {
 }
 
 type errType1 struct{ error }
-type errType2 struct { error }
+type errType2 struct{ error }
 
 func TestErr(t *testing.T) {
 	err := errType1{errors.New("some underlying error")}
@@ -58,4 +59,10 @@ func TestErr(t *testing.T) {
 	// confirm we can only convert se to an error of the same underlying type
 	assert.True(t, errors.As(se, new(errType1)))
 	assert.False(t, errors.As(se, new(errType2)))
+
+	// make sure we don't panic if someone uses it the old way and baseErr is nil
+	se = Err{Time: time.Now(), Err: "something bad"}
+	require.NotPanics(t, func() { _ = se.Error() })
+	assert.Equal(t, "something bad", se.Error())
+	assert.False(t, errors.As(se, new(errType1)))
 }

--- a/statemachine/errors_test.go
+++ b/statemachine/errors_test.go
@@ -1,10 +1,12 @@
 package statemachine_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	. "github.com/lytics/metafora/statemachine"
+	"github.com/stretchr/testify/assert"
 )
 
 type task string
@@ -41,4 +43,19 @@ func TestDefaultErrHandler(t *testing.T) {
 			t.Fatalf("Expected error handler to permanently fail but receied: %s", msg)
 		}
 	}
+}
+
+type errType1 struct{ error }
+type errType2 struct { error }
+
+func TestErr(t *testing.T) {
+	err := errType1{errors.New("some underlying error")}
+	se := NewErr(err, time.Now())
+
+	// confirm se implements the error interface
+	assert.Implements(t, (*error)(nil), se)
+
+	// confirm we can only convert se to an error of the same underlying type
+	assert.True(t, errors.As(se, new(errType1)))
+	assert.False(t, errors.As(se, new(errType2)))
 }

--- a/statemachine/errors_test.go
+++ b/statemachine/errors_test.go
@@ -64,4 +64,11 @@ func TestErr(t *testing.T) {
 	se = Err{Time: time.Now(), Err: "something bad"}
 	assert.Equal(t, "something bad", se.Error())
 	assert.False(t, errors.As(se, new(errType1)))
+
+	// confirm we can check for a specific instance of baseErr too
+	e1 := errType1{errors.New("target instance")}
+	e2 := errType1{errors.New("different instance")}
+	se = NewErr(e1, time.Now())
+	assert.True(t, errors.Is(se, e1))
+	assert.False(t, errors.Is(se, e2))
 }

--- a/statemachine/errors_test.go
+++ b/statemachine/errors_test.go
@@ -54,7 +54,7 @@ func TestErr(t *testing.T) {
 	se := NewErr(err, time.Now())
 
 	// confirm se implements the error interface
-	assert.Implements(t, (*error)(nil), se)
+	require.Implements(t, (*error)(nil), se)
 
 	// confirm we can only convert se to an error of the same underlying type
 	assert.True(t, errors.As(se, new(errType1)))

--- a/statemachine/errors_test.go
+++ b/statemachine/errors_test.go
@@ -62,7 +62,6 @@ func TestErr(t *testing.T) {
 
 	// make sure we don't panic if someone uses it the old way and baseErr is nil
 	se = Err{Time: time.Now(), Err: "something bad"}
-	require.NotPanics(t, func() { _ = se.Error() })
 	assert.Equal(t, "something bad", se.Error())
 	assert.False(t, errors.As(se, new(errType1)))
 }

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -508,7 +508,7 @@ func apply(cur *State, m *Message) (*State, bool) {
 			metafora.Debugf("Transitioned %s", trans)
 			if m.Err != nil {
 				// Append errors from message
-				cur.Errors = append(cur.Errors, Err{Time: time.Now(), Err: m.Err.Error()})
+				cur.Errors = append(cur.Errors, NewErr(m.Err, time.Now()))
 			}
 
 			// New State + Message's Until + Combined Errors


### PR DESCRIPTION
This PR implements the error interface for `statemachine.Err`. The change preserves the existing external interface, implements the error interface, and ~~embeds `error`~~ adds a private field `baseErr` so that the type is a proper error and can be converted back to its underlying error type using `errors.As()`. A constructor is added to simplify instantiation and to allow for testing outside of the `statemachine` package, since we don't want to expose the underlying error directly.

Also updates the go directive in `go.mod` to 1.13, and requires 1.13.x in `.travis.yml` since we're now using features in the `errors` package that were introduced in 1.13