### PR TITLE
Don't save state when it doesn't change

### DIFF
--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -372,17 +372,19 @@ func (s *stateMachine) Run() (done bool) {
 		metafora.Infof("task=%q transitioning %s --> %s --> %s", tid, state, msg, newstate)
 
 		// Save state
-		if err := s.ss.Store(s.task, newstate); err != nil {
-			// After upgrading to 1.25.5-gke.2000 we started experiencing the metadata server throwing POD_FINDER_IP_MISMATCH
-			// errors resulting in failures authenticating to spanner. This panic will cause the pod to cyle
-			// See https://github.com/lytics/lio/issues/30414
-			if strings.Contains(err.Error(), "spanner: code = \"Unauthenticated\"") {
-				metafora.Errorf("task=%q Unable to persist state=%q due to failure to authenticate to spanner.", tid, newstate.Code)
-				panic(err)
-			}
+		if msg.Code != Release {
+			if err := s.ss.Store(s.task, newstate); err != nil {
+				// After upgrading to 1.25.5-gke.2000 we started experiencing the metadata server throwing POD_FINDER_IP_MISMATCH
+				// errors resulting in failures authenticating to spanner. This panic will cause the pod to cyle
+				// See https://github.com/lytics/lio/issues/30414
+				if strings.Contains(err.Error(), "spanner: code = \"Unauthenticated\"") {
+					metafora.Errorf("task=%q Unable to persist state=%q due to failure to authenticate to spanner.", tid, newstate.Code)
+					panic(err)
+				}
 
-			metafora.Errorf("task=%q Unable to persist state=%q. Continuing.", tid, newstate.Code)
-			return true
+				metafora.Errorf("task=%q Unable to persist state=%q. Continuing.", tid, newstate.Code)
+				return true
+			}
 		}
 
 		// Set next state and loop if non-terminal

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -371,8 +371,8 @@ func (s *stateMachine) Run() (done bool) {
 
 		metafora.Infof("task=%q transitioning %s --> %s --> %s", tid, state, msg, newstate)
 
-		// Save state
-		if msg.Code != Release {
+		// Save state - second part of logic probably should never happen
+		if msg.Code != Release || (msg.Code == Release && state.Code != newstate.Code) {
 			if err := s.ss.Store(s.task, newstate); err != nil {
 				// After upgrading to 1.25.5-gke.2000 we started experiencing the metadata server throwing POD_FINDER_IP_MISMATCH
 				// errors resulting in failures authenticating to spanner. This panic will cause the pod to cyle

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -372,7 +372,7 @@ func (s *stateMachine) Run() (done bool) {
 		metafora.Infof("task=%q transitioning %s --> %s --> %s", tid, state, msg, newstate)
 
 		// Save state - second part of logic probably should never happen
-		if msg.Code != Release || (msg.Code == Release && state.Code != newstate.Code) {
+		if msg.Code != Release || (msg.Code == Release && (state.Code != newstate.Code || len(state.Errors) != len(newstate.Errors))) {
 			if err := s.ss.Store(s.task, newstate); err != nil {
 				// After upgrading to 1.25.5-gke.2000 we started experiencing the metadata server throwing POD_FINDER_IP_MISMATCH
 				// errors resulting in failures authenticating to spanner. This panic will cause the pod to cyle


### PR DESCRIPTION
Changes: don't save state change when state doesn't change. 

Save spanner calls and messing with work state history. 