### PR TITLE
Fix inversion of filter

### DIFF
--- a/metcdv3/balancer.go
+++ b/metcdv3/balancer.go
@@ -54,7 +54,7 @@ func (e *etcdClusterState) NodeTaskCount() (map[string]int, error) {
 		// We're guarunteed to find nodes under the _metadata path (created on Coordinator startup)
 		dir, _ := path.Split(string(kv.Key))
 		dir, node := path.Split(path.Clean(dir))
-		if path.Clean(dir) == e.nodePath && !e.filter(&FilterableValue{Name: node}) {
+		if path.Clean(dir) == e.nodePath && e.filter(&FilterableValue{Name: node}) {
 			state[node] = 0
 		}
 	}


### PR DESCRIPTION
The filter was causing us to return all of the /other/ nodes, not our list of nodes. This caused the balancer to do insane things because it was using the entire irrelevant cluster list as the average