### PR TITLE
prevent coordinator deadlock

### DIFF
--- a/ignore.go
+++ b/ignore.go
@@ -93,6 +93,10 @@ func (im *ignoremgr) monitor(tasks chan<- Task, stop <-chan struct{}) {
 			// Notify the consumer
 			select {
 			case tasks <- next.task:
+			case newtask := <-im.incoming:
+				// We always have to listen for incoming tasks to prevent a deadlock
+				heap.Push(&times, newtask)
+				heap.Push(&times, next)
 			case <-stop:
 				return
 			}


### PR DESCRIPTION
deadlock:
The main loop is waiting in ignoremgr.add() to push into incoming not listening on tasks
ignoremgr.monitor() is waiting to push into tasks not listening on incoming