### PR TITLE
add retry logic for revision compaction errors from etcd

### DIFF
--- a/metcdv3/commander.go
+++ b/metcdv3/commander.go
@@ -108,6 +108,55 @@ func (c *cmdListener) Stop() {
 }
 
 func (cl *cmdListener) watch(c context.Context, prefix string) {
+	putTerminalError := func(msg *statemachine.Message) {
+		go func() {
+			select {
+			case <-c.Done():
+				// TODO Do I need the stop channel?
+			case <-cl.stop:
+			case <-time.After(10 * time.Minute):
+				metafora.Warnf("metafora command listener timed out putting message on channel: %v", msg)
+			case cl.commands <- msg:
+			}
+		}()
+	}
+
+	var backoff resyncBackoff
+	for {
+		start := time.Now()
+		err := cl.watchOnce(c, prefix)
+		if err == nil {
+			return // shutdown
+		}
+		if !errors.Is(err, ErrWatchCompacted) {
+			putTerminalError(statemachine.ErrorMessage(err))
+			return
+		}
+
+		delay, escalated := backoff.next(time.Since(start))
+		if escalated {
+			// Re-syncs are failing in a tight loop; fall back to surfacing the
+			// error (faulting the task) rather than re-syncing forever.
+			metafora.Errorf("metafora command listener: watch %s compacted %d times in a row; giving up and faulting task", prefix, backoff.consecutive)
+			putTerminalError(statemachine.ErrorMessage(err))
+			return
+		}
+		metafora.Warnf("metafora command listener: watch revision compacted, re-syncing %s in %s", prefix, delay)
+		select {
+		case <-c.Done():
+			return
+		case <-cl.stop:
+			return
+		case <-time.After(delay):
+		}
+	}
+}
+
+// watchOnce performs a single GET-then-watch episode for a task's commands,
+// emitting command messages as they arrive. It returns ErrWatchCompacted if
+// etcd compacted the watch revision (so watch can re-sync), nil on shutdown, or
+// the underlying error otherwise (the caller faults the task with it).
+func (cl *cmdListener) watchOnce(c context.Context, prefix string) error {
 	// Create a message from an event.
 	createMessage := func(key string, value []byte) (*statemachine.Message, error) {
 		msg := &statemachine.Message{}
@@ -138,102 +187,62 @@ func (cl *cmdListener) watch(c context.Context, prefix string) {
 		}
 	}
 
-	putTerminalError := func(msg *statemachine.Message) {
-		go func() {
-			select {
-			case <-c.Done():
-				// TODO Do I need the stop channel?
-			case <-cl.stop:
-			case <-time.After(10 * time.Minute):
-				metafora.Warnf("metafora command listener timed out putting message on channel: %v", msg)
-			case cl.commands <- msg:
-			}
-		}()
+	getRes, err := cl.kvc.Get(c, prefix, etcdv3.WithPrefix())
+	if err != nil {
+		metafora.Errorf("Error GETting %s - sending error to stateful handler: %v", prefix, err)
+		select {
+		case <-c.Done():
+			// TODO Do I need the stop channel?
+		case <-cl.stop:
+		case cl.commands <- statemachine.ErrorMessage(err):
+		}
+		return nil
 	}
 
-	// Loop so we can re-sync (re-Get + re-watch) if etcd compacts away the
-	// revision we're watching from, which commonly happens during member
-	// restarts/relocations. Surfacing the compacted error to the state machine
-	// would otherwise fault an otherwise-healthy task.
-	var backoff resyncBackoff
-restart:
-	for {
-		getRes, err := cl.kvc.Get(c, prefix, etcdv3.WithPrefix())
+	for _, kv := range getRes.Kvs {
+		key := string(kv.Key)
+		if path.Base(key) == MetadataPath {
+			continue
+		}
+		value := kv.Value
+		msg, err := createMessage(key, value)
 		if err != nil {
-			metafora.Errorf("Error GETting %s - sending error to stateful handler: %v", prefix, err)
-			select {
-			case <-c.Done():
-				// TODO Do I need the stop channel?
-			case <-cl.stop:
-			case cl.commands <- statemachine.ErrorMessage(err):
-			}
-			return
+			msg = statemachine.ErrorMessage(err)
 		}
-
-		for _, kv := range getRes.Kvs {
-			key := string(kv.Key)
-			if path.Base(key) == MetadataPath {
-				continue
-			}
-			value := kv.Value
-			msg, err := createMessage(key, value)
-			if err != nil {
-				msg = statemachine.ErrorMessage(err)
-			}
-			if msg != nil {
-				put(msg)
-			}
+		if msg != nil {
+			put(msg)
 		}
+	}
 
-		// Watch deltas in etcd, with the give prefix, starting
-		// at the revision of the get call above.
-		deltas := cl.etcdv3c.Watch(c, prefix, etcdv3.WithPrefix(), etcdv3.WithRev(getRes.Header.Revision+1), etcdv3.WithFilterDelete())
-		watchStart := time.Now()
-		for {
-			select {
-			case <-c.Done():
-				return
-			case <-cl.stop:
-				return
-			case delta, open := <-deltas:
-				if !open {
-					putTerminalError(statemachine.ErrorMessage(ErrWatchClosedUnexpectedly))
-					return
+	// Watch deltas in etcd, with the give prefix, starting
+	// at the revision of the get call above.
+	deltas := cl.etcdv3c.Watch(c, prefix, etcdv3.WithPrefix(), etcdv3.WithRev(getRes.Header.Revision+1), etcdv3.WithFilterDelete())
+	for {
+		select {
+		case <-c.Done():
+			return nil
+		case <-cl.stop:
+			return nil
+		case delta, open := <-deltas:
+			if !open {
+				return ErrWatchClosedUnexpectedly
+			}
+			if delta.Err() != nil {
+				// A non-zero CompactRevision means etcd compacted away the
+				// revision we started watching from; report it so watch can
+				// re-sync instead of faulting the task.
+				if delta.CompactRevision != 0 {
+					return ErrWatchCompacted
 				}
-				if delta.Err() != nil {
-					// A non-zero CompactRevision means etcd compacted away the
-					// revision we started watching from. Re-sync with a fresh
-					// Get and restart the watch instead of faulting the task.
-					if delta.CompactRevision != 0 {
-						delay, escalated := backoff.next(time.Since(watchStart))
-						if escalated {
-							// Re-syncs are failing in a tight loop; fall back to
-							// surfacing the error rather than re-syncing forever.
-							metafora.Errorf("metafora command listener: watch %s compacted %d times in a row; giving up and faulting task", prefix, backoff.consecutive)
-							putTerminalError(statemachine.ErrorMessage(delta.Err()))
-							return
-						}
-						metafora.Warnf("metafora command listener: watch revision compacted, re-syncing %s in %s", prefix, delay)
-						select {
-						case <-c.Done():
-							return
-						case <-cl.stop:
-							return
-						case <-time.After(delay):
-						}
-						continue restart
-					}
-					putTerminalError(statemachine.ErrorMessage(delta.Err()))
-					return
+				return delta.Err()
+			}
+			for _, event := range delta.Events {
+				msg, err := createMessage(string(event.Kv.Key), event.Kv.Value)
+				if err != nil {
+					msg = statemachine.ErrorMessage(err)
 				}
-				for _, event := range delta.Events {
-					msg, err := createMessage(string(event.Kv.Key), event.Kv.Value)
-					if err != nil {
-						msg = statemachine.ErrorMessage(err)
-					}
-					if msg != nil {
-						put(msg)
-					}
+				if msg != nil {
+					put(msg)
 				}
 			}
 		}

--- a/metcdv3/commander.go
+++ b/metcdv3/commander.go
@@ -16,6 +16,11 @@ import (
 
 var (
 	ErrWatchClosedUnexpectedly = errors.New("metafora: watch closed unexpectedly")
+	// ErrWatchCompacted is reported when etcd has compacted away the revision
+	// the watch was started from (e.g. around member restarts/relocations).
+	// Callers should re-sync with a fresh Get and restart the watch rather
+	// than treating it as fatal.
+	ErrWatchCompacted = errors.New("metafora: watch revision compacted")
 )
 
 type cmdr struct {
@@ -103,18 +108,6 @@ func (c *cmdListener) Stop() {
 }
 
 func (cl *cmdListener) watch(c context.Context, prefix string) {
-	getRes, err := cl.kvc.Get(c, prefix, etcdv3.WithPrefix())
-	if err != nil {
-		metafora.Errorf("Error GETting %s - sending error to stateful handler: %v", prefix, err)
-		select {
-		case <-c.Done():
-			// TODO Do I need the stop channel?
-		case <-cl.stop:
-		case cl.commands <- statemachine.ErrorMessage(err):
-		}
-		return
-	}
-
 	// Create a message from an event.
 	createMessage := func(key string, value []byte) (*statemachine.Message, error) {
 		msg := &statemachine.Message{}
@@ -144,20 +137,6 @@ func (cl *cmdListener) watch(c context.Context, prefix string) {
 		case cl.commands <- msg:
 		}
 	}
-	for _, kv := range getRes.Kvs {
-		key := string(kv.Key)
-		if path.Base(key) == MetadataPath {
-			continue
-		}
-		value := kv.Value
-		msg, err := createMessage(key, value)
-		if err != nil {
-			msg = statemachine.ErrorMessage(err)
-		}
-		if msg != nil {
-			put(msg)
-		}
-	}
 
 	putTerminalError := func(msg *statemachine.Message) {
 		go func() {
@@ -172,31 +151,89 @@ func (cl *cmdListener) watch(c context.Context, prefix string) {
 		}()
 	}
 
-	// Watch deltas in etcd, with the give prefix, starting
-	// at the revision of the get call above.
-	deltas := cl.etcdv3c.Watch(c, prefix, etcdv3.WithPrefix(), etcdv3.WithRev(getRes.Header.Revision+1), etcdv3.WithFilterDelete())
+	// Loop so we can re-sync (re-Get + re-watch) if etcd compacts away the
+	// revision we're watching from, which commonly happens during member
+	// restarts/relocations. Surfacing the compacted error to the state machine
+	// would otherwise fault an otherwise-healthy task.
+	var backoff resyncBackoff
+restart:
 	for {
-		select {
-		case <-c.Done():
-			return
-		case <-cl.stop:
-			return
-		case delta, open := <-deltas:
-			if !open {
-				putTerminalError(statemachine.ErrorMessage(ErrWatchClosedUnexpectedly))
-				return
+		getRes, err := cl.kvc.Get(c, prefix, etcdv3.WithPrefix())
+		if err != nil {
+			metafora.Errorf("Error GETting %s - sending error to stateful handler: %v", prefix, err)
+			select {
+			case <-c.Done():
+				// TODO Do I need the stop channel?
+			case <-cl.stop:
+			case cl.commands <- statemachine.ErrorMessage(err):
 			}
-			if delta.Err() != nil {
-				putTerminalError(statemachine.ErrorMessage(delta.Err()))
-				return
+			return
+		}
+
+		for _, kv := range getRes.Kvs {
+			key := string(kv.Key)
+			if path.Base(key) == MetadataPath {
+				continue
 			}
-			for _, event := range delta.Events {
-				msg, err := createMessage(string(event.Kv.Key), event.Kv.Value)
-				if err != nil {
-					msg = statemachine.ErrorMessage(err)
+			value := kv.Value
+			msg, err := createMessage(key, value)
+			if err != nil {
+				msg = statemachine.ErrorMessage(err)
+			}
+			if msg != nil {
+				put(msg)
+			}
+		}
+
+		// Watch deltas in etcd, with the give prefix, starting
+		// at the revision of the get call above.
+		deltas := cl.etcdv3c.Watch(c, prefix, etcdv3.WithPrefix(), etcdv3.WithRev(getRes.Header.Revision+1), etcdv3.WithFilterDelete())
+		watchStart := time.Now()
+		for {
+			select {
+			case <-c.Done():
+				return
+			case <-cl.stop:
+				return
+			case delta, open := <-deltas:
+				if !open {
+					putTerminalError(statemachine.ErrorMessage(ErrWatchClosedUnexpectedly))
+					return
 				}
-				if msg != nil {
-					put(msg)
+				if delta.Err() != nil {
+					// A non-zero CompactRevision means etcd compacted away the
+					// revision we started watching from. Re-sync with a fresh
+					// Get and restart the watch instead of faulting the task.
+					if delta.CompactRevision != 0 {
+						delay, escalated := backoff.next(time.Since(watchStart))
+						if escalated {
+							// Re-syncs are failing in a tight loop; fall back to
+							// surfacing the error rather than re-syncing forever.
+							metafora.Errorf("metafora command listener: watch %s compacted %d times in a row; giving up and faulting task", prefix, backoff.consecutive)
+							putTerminalError(statemachine.ErrorMessage(delta.Err()))
+							return
+						}
+						metafora.Warnf("metafora command listener: watch revision compacted, re-syncing %s in %s", prefix, delay)
+						select {
+						case <-c.Done():
+							return
+						case <-cl.stop:
+							return
+						case <-time.After(delay):
+						}
+						continue restart
+					}
+					putTerminalError(statemachine.ErrorMessage(delta.Err()))
+					return
+				}
+				for _, event := range delta.Events {
+					msg, err := createMessage(string(event.Kv.Key), event.Kv.Value)
+					if err != nil {
+						msg = statemachine.ErrorMessage(err)
+					}
+					if msg != nil {
+						put(msg)
+					}
 				}
 			}
 		}

--- a/metcdv3/coordinator.go
+++ b/metcdv3/coordinator.go
@@ -99,7 +99,35 @@ func NewEtcdV3Coordinator(conf *Config, client *etcdv3.Client) *EtcdV3Coordinato
 // Watch streams tasks from etcd watches or GETs until Close is called or etcd
 // is unreachable (in which case an error is returned).
 func (ec *EtcdV3Coordinator) Watch(out chan<- metafora.Task) error {
+	var backoff resyncBackoff
+	for {
+		start := time.Now()
+		err := ec.watchOnce(out)
+		if err == nil || !errors.Is(err, ErrWatchCompacted) {
+			return err
+		}
+
+		delay, escalated := backoff.next(time.Since(start))
+		if escalated {
+			metafora.Errorf("metafora etcdv3 coordinator: task watch %s compacted %d times in a row; giving up and returning error", ec.taskPath, backoff.consecutive)
+			return err
+		}
+		metafora.Warnf("metafora etcdv3 coordinator: task watch revision compacted, re-syncing %s in %s", ec.taskPath, delay)
+		select {
+		case <-ec.done:
+			return nil
+		case <-time.After(delay):
+		}
+	}
+}
+
+func (ec *EtcdV3Coordinator) watchOnce(out chan<- metafora.Task) error {
 	c := context.Background()
+	select {
+	case <-ec.done:
+		return nil
+	default:
+	}
 
 	parseTask := func(we *WatchEvent) metafora.Task {
 		// Pickup new tasks
@@ -169,45 +197,67 @@ func (ec *EtcdV3Coordinator) Watch(out chan<- metafora.Task) error {
 		return nil
 	}
 
-	// Loop so we can re-sync (re-Get + re-watch) if etcd compacts away the
-	// revision we're watching from, which commonly happens during member
-	// restarts/relocations.
-	var backoff resyncBackoff
-restart:
+	getRes, err := ec.kvc.Get(c, ec.taskPath, etcdv3.WithPrefix())
+	if err != nil {
+		metafora.Errorf("metafora etcdv3 coordinator: Error GETting %s - sending error to stateful handler: %v", ec.taskPath, err)
+		return err
+	}
+	claimedTasks := make(map[string]struct{})
+	for _, kv := range getRes.Kvs {
+		key := string(kv.Key)
+		dir, end := path.Split(key)
+		if end == OwnerPath {
+			dir = path.Clean(dir)
+			claimedTasks[dir] = struct{}{}
+		}
+	}
+	for _, kv := range getRes.Kvs {
+		key := string(kv.Key)
+		if base := path.Base(key); base == OwnerPath || base == MetadataPath || base == PropsPath {
+			continue
+		}
+		if _, ok := claimedTasks[key]; ok {
+			continue
+		}
+		we := &WatchEvent{
+			Key:   key,
+			Value: kv.Value,
+		}
+		task := parseTask(we)
+		if task != nil {
+			select {
+			case <-c.Done():
+				return nil
+			case <-ec.done:
+				return nil
+			case out <- task:
+			}
+		}
+	}
+
+	watchEvents, err := ec.watch(c, ec.taskPath, getRes.Header.Revision)
+	if err != nil {
+		return err
+	}
+
+	var watchEvent *WatchEvent
 	for {
 		select {
+		case <-c.Done():
+			return nil
 		case <-ec.done:
 			return nil
-		default:
-		}
+		case watchEvent = <-watchEvents:
+			if watchEvent.Error != nil {
+				return watchEvent.Error
+			}
 
-		getRes, err := ec.kvc.Get(c, ec.taskPath, etcdv3.WithPrefix())
-		if err != nil {
-			metafora.Errorf("metafora etcdv3 coordinator: Error GETting %s - sending error to stateful handler: %v", ec.taskPath, err)
-			return err
-		}
-		claimedTasks := make(map[string]struct{})
-		for _, kv := range getRes.Kvs {
-			key := string(kv.Key)
-			dir, end := path.Split(key)
-			if end == OwnerPath {
-				dir = path.Clean(dir)
-				claimedTasks[dir] = struct{}{}
-			}
-		}
-		for _, kv := range getRes.Kvs {
-			key := string(kv.Key)
-			if base := path.Base(key); base == OwnerPath || base == MetadataPath || base == PropsPath {
+			key := string(watchEvent.Key)
+			if base := path.Base(key); base == MetadataPath || base == PropsPath {
 				continue
 			}
-			if _, ok := claimedTasks[key]; ok {
-				continue
-			}
-			we := &WatchEvent{
-				Key:   key,
-				Value: kv.Value,
-			}
-			task := parseTask(we)
+
+			task := parseTask(watchEvent)
 			if task != nil {
 				select {
 				case <-c.Done():
@@ -215,60 +265,6 @@ restart:
 				case <-ec.done:
 					return nil
 				case out <- task:
-				}
-			}
-		}
-
-		watchEvents, err := ec.watch(c, ec.taskPath, getRes.Header.Revision)
-		if err != nil {
-			return err
-		}
-		watchStart := time.Now()
-
-		var watchEvent *WatchEvent
-		for {
-			select {
-			case <-c.Done():
-				return nil
-			case <-ec.done:
-				return nil
-			case watchEvent = <-watchEvents:
-				if watchEvent.Error != nil {
-					if errors.Is(watchEvent.Error, ErrWatchCompacted) {
-						delay, escalated := backoff.next(time.Since(watchStart))
-						if escalated {
-							// Re-syncs are failing in a tight loop; fall back to
-							// surfacing the error rather than re-syncing forever.
-							metafora.Errorf("metafora etcdv3 coordinator: task watch %s compacted %d times in a row; giving up and returning error", ec.taskPath, backoff.consecutive)
-							return watchEvent.Error
-						}
-						metafora.Warnf("metafora etcdv3 coordinator: task watch revision compacted, re-syncing %s in %s", ec.taskPath, delay)
-						select {
-						case <-c.Done():
-							return nil
-						case <-ec.done:
-							return nil
-						case <-time.After(delay):
-						}
-						continue restart
-					}
-					return watchEvent.Error
-				}
-
-				key := string(watchEvent.Key)
-				if base := path.Base(key); base == MetadataPath || base == PropsPath {
-					continue
-				}
-
-				task := parseTask(watchEvent)
-				if task != nil {
-					select {
-					case <-c.Done():
-						return nil
-					case <-ec.done:
-						return nil
-					case out <- task:
-					}
 				}
 			}
 		}
@@ -332,8 +328,44 @@ func (ec *EtcdV3Coordinator) Done(task metafora.Task) {
 	}
 }
 
+// Command returns the next command for this node, blocking until one is
+// available, the coordinator is closed, or an error occurs.
 func (ec *EtcdV3Coordinator) Command() (metafora.Command, error) {
+	var backoff resyncBackoff
+	for {
+		start := time.Now()
+		cmd, err := ec.commandOnce()
+		if err == nil || !errors.Is(err, ErrWatchCompacted) {
+			return cmd, err
+		}
+
+		delay, escalated := backoff.next(time.Since(start))
+		if escalated {
+			metafora.Errorf("metafora etcdv3 coordinator: command watch %s compacted %d times in a row; giving up and returning error", ec.commandPath, backoff.consecutive)
+			return cmd, err
+		}
+		metafora.Warnf("metafora etcdv3 coordinator: command watch revision compacted, re-syncing %s in %s", ec.commandPath, delay)
+		select {
+		case <-ec.done:
+			return nil, nil
+		case <-time.After(delay):
+		}
+	}
+}
+
+func (ec *EtcdV3Coordinator) commandOnce() (metafora.Command, error) {
 	c := context.Background()
+	select {
+	case <-ec.done:
+		return nil, nil
+	default:
+	}
+
+	getRes, err := ec.kvc.Get(c, ec.commandPath, etcdv3.WithPrefix())
+	if err != nil {
+		metafora.Errorf("metafora etcdv3 coordinator: Error GETting %s - sending error to stateful handler: %v", ec.commandPath, err)
+		return nil, err
+	}
 
 	parseCommand := func(we *WatchEvent) (metafora.Command, error) {
 		if _, err := ec.kvc.Delete(c, we.Key, etcdv3.WithPrefix()); err != nil {
@@ -348,79 +380,41 @@ func (ec *EtcdV3Coordinator) Command() (metafora.Command, error) {
 		return cmd, err
 	}
 
-	// Loop so we can re-sync (re-Get + re-watch) if etcd compacts away the
-	// revision we're watching from, which commonly happens during member
-	// restarts/relocations.
-	var backoff resyncBackoff
-restart:
+	for _, kv := range getRes.Kvs {
+		key := string(kv.Key)
+		if path.Base(key) == MetadataPath || key == ec.commandPath {
+			continue
+		}
+
+		we := &WatchEvent{
+			Key:   key,
+			Value: kv.Value,
+		}
+		return parseCommand(we)
+	}
+
+	watchEvents, err := ec.watch(c, ec.commandPath, getRes.Header.Revision)
+	if err != nil {
+		return nil, err
+	}
+
+	var watchEvent *WatchEvent
 	for {
 		select {
+		case <-c.Done():
+			return nil, nil
 		case <-ec.done:
 			return nil, nil
-		default:
-		}
+		case watchEvent = <-watchEvents:
+			if watchEvent.Error != nil {
+				return nil, watchEvent.Error
+			}
 
-		getRes, err := ec.kvc.Get(c, ec.commandPath, etcdv3.WithPrefix())
-		if err != nil {
-			metafora.Errorf("metafora etcdv3 coordinator: Error GETting %s - sending error to stateful handler: %v", ec.commandPath, err)
-			return nil, err
-		}
-
-		for _, kv := range getRes.Kvs {
-			key := string(kv.Key)
-			if path.Base(key) == MetadataPath || key == ec.commandPath {
+			if path.Base(watchEvent.Key) == MetadataPath || watchEvent.Key == ec.commandPath {
 				continue
 			}
 
-			we := &WatchEvent{
-				Key:   key,
-				Value: kv.Value,
-			}
-			return parseCommand(we)
-		}
-
-		watchEvents, err := ec.watch(c, ec.commandPath, getRes.Header.Revision)
-		if err != nil {
-			return nil, err
-		}
-		watchStart := time.Now()
-
-		var watchEvent *WatchEvent
-		for {
-			select {
-			case <-c.Done():
-				return nil, nil
-			case <-ec.done:
-				return nil, nil
-			case watchEvent = <-watchEvents:
-				if watchEvent.Error != nil {
-					if errors.Is(watchEvent.Error, ErrWatchCompacted) {
-						delay, escalated := backoff.next(time.Since(watchStart))
-						if escalated {
-							// Re-syncs are failing in a tight loop; fall back to
-							// surfacing the error rather than re-syncing forever.
-							metafora.Errorf("metafora etcdv3 coordinator: command watch %s compacted %d times in a row; giving up and returning error", ec.commandPath, backoff.consecutive)
-							return nil, watchEvent.Error
-						}
-						metafora.Warnf("metafora etcdv3 coordinator: command watch revision compacted, re-syncing %s in %s", ec.commandPath, delay)
-						select {
-						case <-c.Done():
-							return nil, nil
-						case <-ec.done:
-							return nil, nil
-						case <-time.After(delay):
-						}
-						continue restart
-					}
-					return nil, watchEvent.Error
-				}
-
-				if path.Base(watchEvent.Key) == MetadataPath || watchEvent.Key == ec.commandPath {
-					continue
-				}
-
-				return parseCommand(watchEvent)
-			}
+			return parseCommand(watchEvent)
 		}
 	}
 }

--- a/metcdv3/coordinator.go
+++ b/metcdv3/coordinator.go
@@ -3,6 +3,7 @@ package metcdv3
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -99,11 +100,6 @@ func NewEtcdV3Coordinator(conf *Config, client *etcdv3.Client) *EtcdV3Coordinato
 // is unreachable (in which case an error is returned).
 func (ec *EtcdV3Coordinator) Watch(out chan<- metafora.Task) error {
 	c := context.Background()
-	select {
-	case <-ec.done:
-		return nil
-	default:
-	}
 
 	parseTask := func(we *WatchEvent) metafora.Task {
 		// Pickup new tasks
@@ -173,67 +169,45 @@ func (ec *EtcdV3Coordinator) Watch(out chan<- metafora.Task) error {
 		return nil
 	}
 
-	getRes, err := ec.kvc.Get(c, ec.taskPath, etcdv3.WithPrefix())
-	if err != nil {
-		metafora.Errorf("metafora etcdv3 coordinator: Error GETting %s - sending error to stateful handler: %v", ec.taskPath, err)
-		return err
-	}
-	claimedTasks := make(map[string]struct{})
-	for _, kv := range getRes.Kvs {
-		key := string(kv.Key)
-		dir, end := path.Split(key)
-		if end == OwnerPath {
-			dir = path.Clean(dir)
-			claimedTasks[dir] = struct{}{}
-		}
-	}
-	for _, kv := range getRes.Kvs {
-		key := string(kv.Key)
-		if base := path.Base(key); base == OwnerPath || base == MetadataPath || base == PropsPath {
-			continue
-		}
-		if _, ok := claimedTasks[key]; ok {
-			continue
-		}
-		we := &WatchEvent{
-			Key:   key,
-			Value: kv.Value,
-		}
-		task := parseTask(we)
-		if task != nil {
-			select {
-			case <-c.Done():
-				return nil
-			case <-ec.done:
-				return nil
-			case out <- task:
-			}
-		}
-	}
-
-	watchEvents, err := ec.watch(c, ec.taskPath, getRes.Header.Revision)
-	if err != nil {
-		return err
-	}
-
-	var watchEvent *WatchEvent
+	// Loop so we can re-sync (re-Get + re-watch) if etcd compacts away the
+	// revision we're watching from, which commonly happens during member
+	// restarts/relocations.
+	var backoff resyncBackoff
+restart:
 	for {
 		select {
-		case <-c.Done():
-			return nil
 		case <-ec.done:
 			return nil
-		case watchEvent = <-watchEvents:
-			if watchEvent.Error != nil {
-				return watchEvent.Error
-			}
+		default:
+		}
 
-			key := string(watchEvent.Key)
-			if base := path.Base(key); base == MetadataPath || base == PropsPath {
+		getRes, err := ec.kvc.Get(c, ec.taskPath, etcdv3.WithPrefix())
+		if err != nil {
+			metafora.Errorf("metafora etcdv3 coordinator: Error GETting %s - sending error to stateful handler: %v", ec.taskPath, err)
+			return err
+		}
+		claimedTasks := make(map[string]struct{})
+		for _, kv := range getRes.Kvs {
+			key := string(kv.Key)
+			dir, end := path.Split(key)
+			if end == OwnerPath {
+				dir = path.Clean(dir)
+				claimedTasks[dir] = struct{}{}
+			}
+		}
+		for _, kv := range getRes.Kvs {
+			key := string(kv.Key)
+			if base := path.Base(key); base == OwnerPath || base == MetadataPath || base == PropsPath {
 				continue
 			}
-
-			task := parseTask(watchEvent)
+			if _, ok := claimedTasks[key]; ok {
+				continue
+			}
+			we := &WatchEvent{
+				Key:   key,
+				Value: kv.Value,
+			}
+			task := parseTask(we)
 			if task != nil {
 				select {
 				case <-c.Done():
@@ -241,6 +215,60 @@ func (ec *EtcdV3Coordinator) Watch(out chan<- metafora.Task) error {
 				case <-ec.done:
 					return nil
 				case out <- task:
+				}
+			}
+		}
+
+		watchEvents, err := ec.watch(c, ec.taskPath, getRes.Header.Revision)
+		if err != nil {
+			return err
+		}
+		watchStart := time.Now()
+
+		var watchEvent *WatchEvent
+		for {
+			select {
+			case <-c.Done():
+				return nil
+			case <-ec.done:
+				return nil
+			case watchEvent = <-watchEvents:
+				if watchEvent.Error != nil {
+					if errors.Is(watchEvent.Error, ErrWatchCompacted) {
+						delay, escalated := backoff.next(time.Since(watchStart))
+						if escalated {
+							// Re-syncs are failing in a tight loop; fall back to
+							// surfacing the error rather than re-syncing forever.
+							metafora.Errorf("metafora etcdv3 coordinator: task watch %s compacted %d times in a row; giving up and returning error", ec.taskPath, backoff.consecutive)
+							return watchEvent.Error
+						}
+						metafora.Warnf("metafora etcdv3 coordinator: task watch revision compacted, re-syncing %s in %s", ec.taskPath, delay)
+						select {
+						case <-c.Done():
+							return nil
+						case <-ec.done:
+							return nil
+						case <-time.After(delay):
+						}
+						continue restart
+					}
+					return watchEvent.Error
+				}
+
+				key := string(watchEvent.Key)
+				if base := path.Base(key); base == MetadataPath || base == PropsPath {
+					continue
+				}
+
+				task := parseTask(watchEvent)
+				if task != nil {
+					select {
+					case <-c.Done():
+						return nil
+					case <-ec.done:
+						return nil
+					case out <- task:
+					}
 				}
 			}
 		}
@@ -306,17 +334,6 @@ func (ec *EtcdV3Coordinator) Done(task metafora.Task) {
 
 func (ec *EtcdV3Coordinator) Command() (metafora.Command, error) {
 	c := context.Background()
-	select {
-	case <-ec.done:
-		return nil, nil
-	default:
-	}
-
-	getRes, err := ec.kvc.Get(c, ec.commandPath, etcdv3.WithPrefix())
-	if err != nil {
-		metafora.Errorf("metafora etcdv3 coordinator: Error GETting %s - sending error to stateful handler: %v", ec.commandPath, err)
-		return nil, err
-	}
 
 	parseCommand := func(we *WatchEvent) (metafora.Command, error) {
 		if _, err := ec.kvc.Delete(c, we.Key, etcdv3.WithPrefix()); err != nil {
@@ -331,41 +348,79 @@ func (ec *EtcdV3Coordinator) Command() (metafora.Command, error) {
 		return cmd, err
 	}
 
-	for _, kv := range getRes.Kvs {
-		key := string(kv.Key)
-		if path.Base(key) == MetadataPath || key == ec.commandPath {
-			continue
-		}
-
-		we := &WatchEvent{
-			Key:   key,
-			Value: kv.Value,
-		}
-		return parseCommand(we)
-	}
-
-	watchEvents, err := ec.watch(c, ec.commandPath, getRes.Header.Revision)
-	if err != nil {
-		return nil, err
-	}
-
-	var watchEvent *WatchEvent
+	// Loop so we can re-sync (re-Get + re-watch) if etcd compacts away the
+	// revision we're watching from, which commonly happens during member
+	// restarts/relocations.
+	var backoff resyncBackoff
+restart:
 	for {
 		select {
-		case <-c.Done():
-			return nil, nil
 		case <-ec.done:
 			return nil, nil
-		case watchEvent = <-watchEvents:
-			if watchEvent.Error != nil {
-				return nil, watchEvent.Error
-			}
+		default:
+		}
 
-			if path.Base(watchEvent.Key) == MetadataPath || watchEvent.Key == ec.commandPath {
+		getRes, err := ec.kvc.Get(c, ec.commandPath, etcdv3.WithPrefix())
+		if err != nil {
+			metafora.Errorf("metafora etcdv3 coordinator: Error GETting %s - sending error to stateful handler: %v", ec.commandPath, err)
+			return nil, err
+		}
+
+		for _, kv := range getRes.Kvs {
+			key := string(kv.Key)
+			if path.Base(key) == MetadataPath || key == ec.commandPath {
 				continue
 			}
 
-			return parseCommand(watchEvent)
+			we := &WatchEvent{
+				Key:   key,
+				Value: kv.Value,
+			}
+			return parseCommand(we)
+		}
+
+		watchEvents, err := ec.watch(c, ec.commandPath, getRes.Header.Revision)
+		if err != nil {
+			return nil, err
+		}
+		watchStart := time.Now()
+
+		var watchEvent *WatchEvent
+		for {
+			select {
+			case <-c.Done():
+				return nil, nil
+			case <-ec.done:
+				return nil, nil
+			case watchEvent = <-watchEvents:
+				if watchEvent.Error != nil {
+					if errors.Is(watchEvent.Error, ErrWatchCompacted) {
+						delay, escalated := backoff.next(time.Since(watchStart))
+						if escalated {
+							// Re-syncs are failing in a tight loop; fall back to
+							// surfacing the error rather than re-syncing forever.
+							metafora.Errorf("metafora etcdv3 coordinator: command watch %s compacted %d times in a row; giving up and returning error", ec.commandPath, backoff.consecutive)
+							return nil, watchEvent.Error
+						}
+						metafora.Warnf("metafora etcdv3 coordinator: command watch revision compacted, re-syncing %s in %s", ec.commandPath, delay)
+						select {
+						case <-c.Done():
+							return nil, nil
+						case <-ec.done:
+							return nil, nil
+						case <-time.After(delay):
+						}
+						continue restart
+					}
+					return nil, watchEvent.Error
+				}
+
+				if path.Base(watchEvent.Key) == MetadataPath || watchEvent.Key == ec.commandPath {
+					continue
+				}
+
+				return parseCommand(watchEvent)
+			}
 		}
 	}
 }
@@ -598,6 +653,13 @@ func (ec *EtcdV3Coordinator) watch(c context.Context, prefix string, revision in
 		defer close(watchEvents)
 		for delta := range deltas {
 			if delta.Err() != nil {
+				// A non-zero CompactRevision means etcd compacted away the
+				// revision we started watching from. Surface a recognizable
+				// error so callers can re-sync instead of treating it as fatal.
+				if delta.CompactRevision != 0 {
+					putTerminalError(&WatchEvent{Error: ErrWatchCompacted})
+					return
+				}
 				putTerminalError(&WatchEvent{Error: delta.Err()})
 				return
 			}

--- a/metcdv3/resync.go
+++ b/metcdv3/resync.go
@@ -1,0 +1,58 @@
+package metcdv3
+
+import "time"
+
+const (
+	// resyncBackoffMin is the initial delay before re-syncing a watch after a
+	// compaction; resyncBackoffMax is the ceiling for exponential growth. The
+	// delay throttles the re-Get/re-watch loop so a pathological compaction
+	// storm can't hammer etcd while it's already unhealthy (the condition
+	// commonly coincides with member restarts/relocations).
+	resyncBackoffMin = 500 * time.Millisecond
+	resyncBackoffMax = 30 * time.Second
+
+	// resyncHealthyThreshold is how long a watch must run before a subsequent
+	// compaction is treated as a fresh, isolated event (resetting the backoff)
+	// rather than part of a tight failure loop.
+	resyncHealthyThreshold = 30 * time.Second
+
+	// resyncEscalateAfter is the number of consecutive rapid resyncs after
+	// which we give up re-syncing and fall back to the original behavior of
+	// surfacing the compaction error (panicking the consumer loop / faulting
+	// the task). A single compaction always recovers via a fresh Get, so
+	// reaching this threshold means resyncs are failing in a tight loop, i.e.
+	// etcd is persistently unhealthy and the error should be surfaced.
+	resyncEscalateAfter = 5
+)
+
+// resyncBackoff tracks exponential backoff between watch resync attempts. It is
+// not safe for concurrent use; each watch goroutine owns its own.
+type resyncBackoff struct {
+	cur         time.Duration
+	consecutive int
+}
+
+// next records a resync that followed a watch which ran for watchedFor and
+// returns how long to wait before retrying and whether the situation has
+// escalated (too many rapid resyncs in a row). A watch that ran longer than
+// resyncHealthyThreshold resets the backoff, so an isolated compaction always
+// incurs only the minimum delay.
+func (b *resyncBackoff) next(watchedFor time.Duration) (delay time.Duration, escalated bool) {
+	if watchedFor >= resyncHealthyThreshold {
+		b.cur = 0
+		b.consecutive = 0
+	}
+
+	switch {
+	case b.cur < resyncBackoffMin:
+		b.cur = resyncBackoffMin
+	default:
+		b.cur *= 2
+		if b.cur > resyncBackoffMax {
+			b.cur = resyncBackoffMax
+		}
+	}
+	b.consecutive++
+
+	return b.cur, b.consecutive >= resyncEscalateAfter
+}

--- a/metcdv3/resync_test.go
+++ b/metcdv3/resync_test.go
@@ -1,0 +1,67 @@
+package metcdv3
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResyncBackoffExponentialAndCap(t *testing.T) {
+	var b resyncBackoff
+
+	// Rapid resyncs (watch never ran long) should grow exponentially from the
+	// minimum and never exceed the maximum.
+	prev := time.Duration(0)
+	for i := 0; i < 20; i++ {
+		delay, _ := b.next(0)
+		if delay < resyncBackoffMin {
+			t.Fatalf("attempt %d: delay %s below min %s", i, delay, resyncBackoffMin)
+		}
+		if delay > resyncBackoffMax {
+			t.Fatalf("attempt %d: delay %s above max %s", i, delay, resyncBackoffMax)
+		}
+		if i > 0 && delay < prev {
+			t.Fatalf("attempt %d: delay %s decreased from %s without a reset", i, delay, prev)
+		}
+		prev = delay
+	}
+	if prev != resyncBackoffMax {
+		t.Fatalf("expected backoff to reach cap %s, got %s", resyncBackoffMax, prev)
+	}
+}
+
+func TestResyncBackoffEscalates(t *testing.T) {
+	var b resyncBackoff
+	for i := 1; i < resyncEscalateAfter; i++ {
+		if _, escalated := b.next(0); escalated {
+			t.Fatalf("escalated early at consecutive=%d", b.consecutive)
+		}
+	}
+	if _, escalated := b.next(0); !escalated {
+		t.Fatalf("expected escalation at consecutive=%d (threshold %d)", b.consecutive, resyncEscalateAfter)
+	}
+}
+
+func TestResyncBackoffResetsAfterHealthyWatch(t *testing.T) {
+	var b resyncBackoff
+
+	// Drive the backoff up and into escalation.
+	for i := 0; i < resyncEscalateAfter+3; i++ {
+		b.next(0)
+	}
+	if b.cur <= resyncBackoffMin {
+		t.Fatalf("precondition: expected elevated backoff, got %s", b.cur)
+	}
+
+	// A watch that ran longer than the healthy threshold is an isolated
+	// compaction: backoff resets to the minimum and escalation clears.
+	delay, escalated := b.next(resyncHealthyThreshold)
+	if delay != resyncBackoffMin {
+		t.Fatalf("expected reset to min %s, got %s", resyncBackoffMin, delay)
+	}
+	if escalated {
+		t.Fatal("expected escalation to clear after a healthy watch")
+	}
+	if b.consecutive != 1 {
+		t.Fatalf("expected consecutive=1 after reset, got %d", b.consecutive)
+	}
+}


### PR DESCRIPTION
  **Problem**                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  During etcd member restarts/relocations, the client's watch can be asked to resume from a revision etcd has already compacted, surfacing mvcc: required revision has been compacted. The coordinator treated this as fatal:                                                                                      
                                                                                                                                                                                                                                                                                                                   
  - Command() and the task Watch() returned the error, which the consumer's main loop turns into a panic (metafora.go).                                                                                                                                                                                            
  - The CommandListener forwarded it to the state machine, faulting an otherwise-healthy task.    
                                                                                                                                                                                                                                                                                                           
  This is expected, recoverable etcd behavior                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                   
  **Fix**                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  When a watch reports a compacted revision (WatchResponse.CompactRevision != 0), re-sync instead of failing: re-Get the current state and restart the watch from the fresh revision. Applied to all three watch sites — Command(), Watch(), and CommandListener.                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                   
  Re-syncing is safe (no double-processing): commands are deleted on handling so a re-Get can't re-surface them, and tasks are filtered by ownership on re-Get and de-duplicated again by the idempotent Claim/running checks.                                                                                     
                                                                                                                                                                                                                                                                                                                   
  **Backoff & safety valve**                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                   
  A capped exponential backoff (500ms → 30s) throttles the re-sync loop so it can't hammer etcd while it's already unhealthy. The backoff resets after a watch runs healthily, so an isolated compaction incurs only the minimum delay. If re-syncs fail in a tight loop (5 consecutive without a healthy watch —  
  i.e. etcd is persistently broken), it falls back to the original behavior (surface the error) rather than retrying forever. 