### PR TITLE
fix(metcdv3): resolve owner key from the task path, and log dropped commands honestly

### DIFF
--- a/metcdv3/commander.go
+++ b/metcdv3/commander.go
@@ -50,10 +50,12 @@ func (c *cmdr) Send(taskID string, m *statemachine.Message) error {
 }
 
 type cmdListener struct {
-	etcdv3c     *etcdv3.Client
-	kvc         etcdv3.KV
-	name        string
-	taskcmdpath string
+	etcdv3c       *etcdv3.Client
+	kvc           etcdv3.KV
+	name          string
+	taskid        string
+	taskcmdpath   string
+	taskownerpath string
 
 	commands chan *statemachine.Message
 
@@ -66,20 +68,22 @@ type cmdListener struct {
 // backed by etcd. The namespace should be the same as the coordinator as
 // commands use a separate path within a namespace than tasks or nodes.
 func NewCommandListener(conf *Config, task metafora.Task, c *etcdv3.Client) statemachine.CommandListener {
-	taskcmdpath := path.Join("/", conf.Namespace, TasksPath, task.ID(), CommandsPath)
+	taskpath := path.Join("/", conf.Namespace, TasksPath, task.ID())
 
 	ctxt, cancel := context.WithCancel(context.Background())
 	cl := &cmdListener{
-		etcdv3c:     c,
-		name:        conf.Name,
-		taskcmdpath: taskcmdpath,
-		kvc:         etcdv3.NewKV(c),
-		commands:    make(chan *statemachine.Message),
-		mu:          &sync.Mutex{},
-		stop:        make(chan bool),
-		cancel:      cancel,
+		etcdv3c:       c,
+		name:          conf.Name,
+		taskid:        task.ID(),
+		taskcmdpath:   path.Join(taskpath, CommandsPath),
+		taskownerpath: path.Join(taskpath, OwnerPath),
+		kvc:           etcdv3.NewKV(c),
+		commands:      make(chan *statemachine.Message),
+		mu:            &sync.Mutex{},
+		stop:          make(chan bool),
+		cancel:        cancel,
 	}
-	go cl.watch(ctxt, taskcmdpath)
+	go cl.watch(ctxt, cl.taskcmdpath)
 	return cl
 }
 
@@ -165,16 +169,21 @@ func (cl *cmdListener) watchOnce(c context.Context, prefix string) error {
 			return nil, err
 		}
 
+		// Compare against the owner key built from the task path. Deriving it
+		// from the command key's parent instead silently resolves to the wrong
+		// key if the command ever moves within the prefix being watched.
 		txnRes, err := cl.kvc.Txn(c).
-			If(etcdv3.Compare(etcdv3.Value(path.Join(path.Dir(key), OwnerPath)), "=", cl.ownerValueString())).
-			Then(etcdv3.OpDelete(key, etcdv3.WithPrefix())).
+			If(etcdv3.Compare(etcdv3.Value(cl.taskownerpath), "=", cl.ownerValueString())).
+			Then(etcdv3.OpDelete(key)).
 			Commit()
 		if err != nil {
 			metafora.Errorf("Error deleting command %s: %s - sending error to stateful handler: %v", key, msg, err)
 			return nil, err
 		}
 		if !txnRes.Succeeded {
-			metafora.Infof("Received successive commands; attempting to retrieve the latest")
+			// This node no longer owns the task, so it must not consume the
+			// command; whoever holds the claim will pick it up instead.
+			metafora.Warnf("task=%q no longer owned by %s, leaving command %s at %s for the new owner", cl.taskid, cl.name, msg, key)
 			return nil, nil
 		}
 		return msg, nil

--- a/metcdv3/commander_test.go
+++ b/metcdv3/commander_test.go
@@ -69,3 +69,49 @@ func TestCommandListener(t *testing.T) {
 		// Ok
 	}
 }
+
+// A listener on a node that doesn't hold the claim must neither consume the
+// command nor delete it, so the node that does hold the claim still gets it.
+func TestCommandListenerLeavesCommandsForTheOwner(t *testing.T) {
+	t.Parallel()
+
+	etcdv3c, _, conf := setupEtcd(t)
+	kvc := etcdv3.NewKV(etcdv3c)
+
+	namespace := "/clnotownedtest"
+	conf.Namespace = namespace
+	_, _ = kvc.Delete(context.Background(), namespace, etcdv3.WithPrefix())
+
+	task := metafora.NewTask("testtask")
+	cmdpath := path.Join(namespace, TasksPath, task.ID(), CommandsPath)
+
+	// Claimed by somebody else.
+	_, err := kvc.Put(context.Background(),
+		path.Join(namespace, TasksPath, task.ID(), OwnerPath), `{"node":"someothernode"}`)
+	if err != nil {
+		t.Fatalf("Error creating fake claim: %v", err)
+	}
+
+	if err := NewCommander(namespace, etcdv3c).Send(task.ID(), statemachine.RunMessage()); err != nil {
+		t.Fatalf("Error sending command: %v", err)
+	}
+
+	cl := NewCommandListener(conf, task, etcdv3c)
+	defer cl.Stop()
+
+	select {
+	case cmd := <-cl.Receive():
+		t.Fatalf("Received a command for a task this node doesn't own: %v", cmd)
+	case <-time.After(time.Second):
+		// Ok!
+	}
+
+	// The command must still be there for the real owner.
+	res, err := kvc.Get(context.Background(), cmdpath)
+	if err != nil {
+		t.Fatalf("Error reading command back: %v", err)
+	}
+	if res.Count != 1 {
+		t.Fatalf("Expected the command to survive, found %d keys at %s", res.Count, cmdpath)
+	}
+}


### PR DESCRIPTION
Three fixes in `metcdv3`'s command-listener ownership check, found while diagnosing a lost workflow command in lytics/lio#39139.

**All three are behavior-neutral with the current single-key command layout.** The added test passes both before and after — it covers a path that had none, rather than pinning a bug. This is hygiene: it removes a landmine and makes a dropped command traceable.

### 1. Build the owner key from the task path, not from the command key

```go
If(etcdv3.Compare(etcdv3.Value(path.Join(path.Dir(key), OwnerPath)), ...))
```

Walking up from the command key happens to land on `…/<task>/owner` today, because the command lives exactly one level below the task. It stops being right the moment a command sits anywhere else under the watched prefix — and the failure is silent and total: a wrong owner key means the compare never matches, so *every* command is discarded with only an info log. That is a bad landmine to leave for whoever changes this layout next.

The path is fully known when the listener is constructed, so it's built there now.

### 2. Delete one key, not a prefix

```go
Then(etcdv3.OpDelete(key, etcdv3.WithPrefix()))
```

`key` is already an exact command key. `WithPrefix` widens the delete to anything that later appears beneath it, which is not what consuming a single command should do.

### 3. Say what actually happens when a command is dropped

```go
metafora.Infof("Received successive commands; attempting to retrieve the latest")
```

When the ownership compare fails, the command is deliberately left in etcd for whoever holds the claim — that part is correct. The log is not: nothing retrieves anything, and the line carries **no task ID**, so a dropped command is untraceable. Chasing lytics/lio#39139 I had to rule this path out by reading the source, because no log line could confirm or deny it. Now it states what happened, at warn, with the task and the key.

### Testing

`ETCDTESTS=1 go test ./metcdv3/...` passes in full (~26s).

New: `TestCommandListenerLeavesCommandsForTheOwner` — a listener on a node that does not hold the claim must neither deliver the command nor delete it, so the real owner still receives it. Verified it passes against unmodified `master` as well, confirming these changes don't alter today's behavior.

Note: `go test ./statemachine/` hangs on `master`, unrelated to this change and untouched here.
